### PR TITLE
add a python3 jupyter kernel to shiny modules qmd

### DIFF
--- a/docs/workflow-modules.qmd
+++ b/docs/workflow-modules.qmd
@@ -1,5 +1,6 @@
 ---
 title: Shiny Modules
+jupyter: python3
 ---
 ## Introduction
 


### PR DESCRIPTION
The rendering process was picking up a different jupyter kernel for me by defualt.
All of the `.qmd` files should probably have a `jupyter: python3` line in it, but fixing this one specifically got me to build the site properly.