### PR TITLE
fix indendation for render

### DIFF
--- a/components/display-messages/help-text.qmd
+++ b/components/display-messages/help-text.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Help Text"
-sidebar: components 
+sidebar: components
 previewapp: |
   from shiny import App, reactive, ui
 
@@ -25,16 +25,16 @@ listing:
       preview: https://shinylive.io/py/app/#h=0&code=NobwRAdghgtgpmAXGKAHVA6VBPMAaMAYwHsIAXOcpMAMwCdiYACAZwAsBLCbJjmVYnTJMAgujxM6cKITIcAbnAkBXDgB0IGtKgD6qpgF4mqrFADmcHTQA2qgCYAKDUxfGOGNnGu6KADzJOYAAKUiwsTGSeTABGymRkpDFexADuEcQYmWpgAJR4zq4mZOYsGNF0DnkFLiZcqHE6MnKkOrHxpIHsqdkS2QDC1hyEANZMALJwPbwQgxBwhkwAYlDWLHA5GhuaEHZwNKxwdIoVdXESxHH1ZBJrYRykOYjVknBkynQQTABypJPb2gsxKgHNo9BwbodjjkwABfAC6QA
       code: |
         from shiny import App, reactive, ui
-        
+
         app_ui = ui.page_fluid(
             ui.help_text("Press the button below to..."), #<<
             ui.tags.br(),
             ui.input_action_button("show", "Click Me")
         )
-        
+
         def server(input, output, session):
             return None
-        
+
         app = App(app_ui, server)
       relevantfunctions:
         - title: "ui.help_text"
@@ -42,9 +42,9 @@ listing:
           signature: ui.help_text(*args, **kwargs)
       details: |
 
-[`ui.help_text()`](TODO ADD LINK TO UI HELP TEXT) creates stylized help text which can be added to the user interface to provide additional explanation or context. 
+        [`ui.help_text()`](TODO ADD LINK TO UI HELP TEXT) creates stylized help text which can be added to the user interface to provide additional explanation or context.
 
-To create help text, call `ui.help_text()` at a desired location from within your `app_ui`. Then pass `ui.help_text()` one or more help text strings (or other inline HTML elements) to place into the `app_ui`.
+        To create help text, call `ui.help_text()` at a desired location from within your `app_ui`. Then pass `ui.help_text()` one or more help text strings (or other inline HTML elements) to place into the `app_ui`.
 
         ## See Also
 
@@ -59,4 +59,3 @@ To create help text, call `ui.help_text()` at a desired location from within you
 
 :::{.component}
 :::
-


### PR DESCRIPTION
fixes this error:

```
% make serve
. venv/bin/activate && quarto preview
ERROR: YAMLError: /Users/danielchen/git/rstudio/py-shiny-site/components/display-messages/help-text.qmd:
missed comma between flow collection entries at line 45, column 2:
    [`ui.help_text()`](TODO ADD LINK  ... 
     ^

Stack trace:
missed comma between flow collection entries at line 45, column 2:
    [`ui.help_text()`](TODO ADD LINK  ... 
     ^
    at generateError (file:///Applications/quarto/bin/quarto.js:10497:12)
    at throwError (file:///Applications/quarto/bin/quarto.js:10500:11)
    at readFlowCollection (file:///Applications/quarto/bin/quarto.js:10883:20)
    at composeNode (file:///Applications/quarto/bin/quarto.js:11316:137)
    at readBlockMapping (file:///Applications/quarto/bin/quarto.js:11096:20)
    at composeNode (file:///Applications/quarto/bin/quarto.js:11316:84)
    at readDocument (file:///Applications/quarto/bin/quarto.js:11430:5)
    at loadDocuments (file:///Applications/quarto/bin/quarto.js:11465:9)
    at load (file:///Applications/quarto/bin/quarto.js:11470:23)
    at parse3 (file:///Applications/quarto/bin/quarto.js:11480:12)
make: *** [serve] Error 1
```