### PR TITLE
Avoid Stamen basemaps in ipyleaflet example

### DIFF
--- a/docs/outputs.qmd
+++ b/docs/outputs.qmd
@@ -169,9 +169,8 @@ import ipyleaflet as L
 basemaps = {
   "Satellite": L.basemaps.Gaode.Satellite,
   "OpenStreetMap": L.basemaps.OpenStreetMap.Mapnik,
-  "Stamen.Toner": L.basemaps.Stamen.Toner,
-  "Stamen.Terrain": L.basemaps.Stamen.Terrain,
-  "Stamen.Watercolor": L.basemaps.Stamen.Watercolor,
+  "WorldStreetMap": L.basemaps.Esri.WorldStreetMap,
+  "NatGeoWorldMap": L.basemaps.Esri.NatGeoWorldMap
 }
 
 app_ui = ui.page_fluid(


### PR DESCRIPTION
This example is currently broken (I'm pretty sure because a recent ipyleaflet release removed the Stamen basemaps)