### PR TITLE
Update to shinylive 0.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.1.1
+shinylive==0.1.3
 matplotlib==3.8.1
 shiny
 seaborn==0.13.0


### PR DESCRIPTION
This PR updates shinylive to 0.1.3, which includes Shiny 0.6.1. This allows the use of Shiny Express in code blocks.