### PR TITLE
fix: Insert shinylive button without breaking code copy btn

### DIFF
--- a/include-in-header.html
+++ b/include-in-header.html
@@ -60,7 +60,7 @@
 
         const btnCopy = el.querySelector(".code-copy-button");
         if (btnCopy) {
-          btnCopy.parentElement.insertBefore(link, btnCopy);
+          btnCopy.parentElement.appendChild(link);
         } else {
           if (el.matches("pre")) {
             el.appendChild(link);


### PR DESCRIPTION
Fixes #104

We needed to insert the shinylive link button _after_ the code copy button, I think that quarto's javascript logic finds the copy button's previous sibling to find the code to copy.