### PR TITLE
Fix components gallery missing Variations heading

### DIFF
--- a/components/_partials/components-list.ejs
+++ b/components/_partials/components-list.ejs
@@ -4,7 +4,7 @@
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="<%= item.path %>">
-<h5><%= item.title %></h5>
+<div class="h5"><%= item.title %></div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="<%= item.path %>">
@@ -26,7 +26,7 @@
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="<%= item.path %>">
-<h5><%= item.title %></h5>
+<div class="h5"><%= item.title %></div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="<%= item.path %>">

--- a/components/_partials/components.css
+++ b/components/_partials/components.css
@@ -193,3 +193,14 @@ main a.nav-link:hover {
   border: 1px solid #e9ecef;
   border-radius: 10px;
 }
+
+/* Add rule and spacing between sections */
+section.level2:not(:first-child) h2 {
+  border-top: 1px solid var(--bs-primary);
+  padding-top: 5rem !important;
+  margin-top: 5rem !important;
+}
+
+section.level2:not(:first-child) > :last-child {
+  margin-bottom: 0;
+}

--- a/components/display-messages/modal/index.qmd
+++ b/components/display-messages/modal/index.qmd
@@ -80,7 +80,7 @@ def _():
     ui.modal_show(m)
 ```
 
-## Modal contents
+### Modal contents
 
 To add elements to a modal, pass them as unnamed arguments to `ui.modal()`. Modals can contain any UI elements recognized by Shiny.
 

--- a/components/display-messages/notifications/index.qmd
+++ b/components/display-messages/notifications/index.qmd
@@ -86,15 +86,16 @@ def _():
 
 You can call [`ui.notification_remove()`](https://shiny.posit.co/py/api/ui.notification_remove.html) to remove a notification programatically, but usually app developers will let notifications expire on their own. Also, notifications come by default with a button that the user can click to close the notification prematurely.
 
-## Duration
+### Duration
 
 By default, Shiny notifications will disappear after five seconds. To change how long a notification appears for, set the `duration` argument of `ui.notification_show()` to an integer number of seconds. Set `duration` to `None` to have the notification appear until the user closes it.
 
-## Type
+### Type
 
 Shiny notifications come in four types: default, messages, warnings and errors. To set the type of a notification, use the `type` argument of `ui.notification_show()`.
 
 See Also: [Modal messages](../modal/index.qmd) provide a similar, but alternative way to display information to the user.
+
 ## Variations
 
 :::{#variations}

--- a/components/display-messages/notifications/index.qmd
+++ b/components/display-messages/notifications/index.qmd
@@ -95,6 +95,7 @@ By default, Shiny notifications will disappear after five seconds. To change how
 Shiny notifications come in four types: default, messages, warnings and errors. To set the type of a notification, use the `type` argument of `ui.notification_show()`.
 
 See Also: [Modal messages](../modal/index.qmd) provide a similar, but alternative way to display information to the user.
+## Variations
 
 :::{#variations}
 :::

--- a/components/display-messages/tooltips/index.qmd
+++ b/components/display-messages/tooltips/index.qmd
@@ -63,7 +63,7 @@ Optionally assign the tooltip an `id` to trigger reactions when the tooltip beco
 
 Control the placement of the tooltip relative to the item it highlights with the `placement` argument. `placement` defaults to `'auto'`, but can be set to one of `'top'`, `'bottom'`, `'left'`, or `'right'`.
 
-## Accessibility of Tooltip Triggers
+### Accessibility of Tooltip Triggers
 
 Because the user needs to interact with the `trigger` element to see the `tooltip`, it's best practice to use an element that is typically accessible via keyboard interactions, like a button or a link.
 
@@ -102,6 +102,7 @@ ui.tooltip(
 Compare tooltips to [popovers](https://shiny.posit.co/py/api/ui.popover.html), which are a similar device for organizing the layout of a Shiny app.
 
 See Also: [Modal messages](../modal/index.qmd) and [notications](../notifications/index.qmd) provide a similar, but alternative way to display information to the user.
+
 ## Variations
 
 :::{#variations}

--- a/components/display-messages/tooltips/index.qmd
+++ b/components/display-messages/tooltips/index.qmd
@@ -102,6 +102,7 @@ ui.tooltip(
 Compare tooltips to [popovers](https://shiny.posit.co/py/api/ui.popover.html), which are a similar device for organizing the layout of a Shiny app.
 
 See Also: [Modal messages](../modal/index.qmd) and [notications](../notifications/index.qmd) provide a similar, but alternative way to display information to the user.
+## Variations
 
 :::{#variations}
 :::

--- a/components/index.qmd
+++ b/components/index.qmd
@@ -36,11 +36,13 @@ listing:
 :::::::: {.column-screen-inset .mx-auto style="max-width: 1300px;"}
 :::::: {.grid .hero-area .my-md-0 .my-5}
 :::: {.g-col-md-7 .g-col-12 .pe-0 .pe-md-5 .my-auto}
-::: {.display-3 .fw-bold}
-Shiny Components
-:::
 
-##### Inputs, outputs and display messages to make your data interactive on every device. Add these components to [Shiny Layouts](/layouts/index.qmd) to give your app a navbar, sidebar, cards and more.
+<h1 class="display-3 fw-bold">Shiny Components</h1>
+
+::: {.h5}
+Inputs, outputs and display messages to make your data interactive on every device.
+Add these components to [Shiny Layouts](/layouts/index.qmd) to give your app a navbar, sidebar, cards and more.
+:::
 
 ::::
 :::: {.g-col-md-5 .g-col-10 .g-start-4 .components-hero-img-container}

--- a/components/inputs/select-multiple/index.qmd
+++ b/components/inputs/select-multiple/index.qmd
@@ -71,6 +71,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<select_id>()` (e.g., `input.select()`) to access the selected value(s). The server value of a select list is a list of strings.
 
 See also: [Select (Single)](../select-single/index.qmd) and [Selectize (Multiple)](../selectize-multiple/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+## Variations
 
 :::{#variations}
 :::

--- a/components/inputs/select-multiple/index.qmd
+++ b/components/inputs/select-multiple/index.qmd
@@ -71,6 +71,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<select_id>()` (e.g., `input.select()`) to access the selected value(s). The server value of a select list is a list of strings.
 
 See also: [Select (Single)](../select-single/index.qmd) and [Selectize (Multiple)](../selectize-multiple/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+
 ## Variations
 
 :::{#variations}

--- a/components/inputs/select-single/index.qmd
+++ b/components/inputs/select-single/index.qmd
@@ -70,6 +70,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<select_id>()` (e.g., `input.select()`) to access the selected value. The server value of a select list is a list of strings. When `multiple=False`, this list will have length 1.
 
 See also: [Select (Multiple)](../select-multiple/index.qmd) and [Selectize (Multiple)](../selectize-multiple/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+## Variations
 
 :::{#variations}
 :::

--- a/components/inputs/select-single/index.qmd
+++ b/components/inputs/select-single/index.qmd
@@ -70,6 +70,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<select_id>()` (e.g., `input.select()`) to access the selected value. The server value of a select list is a list of strings. When `multiple=False`, this list will have length 1.
 
 See also: [Select (Multiple)](../select-multiple/index.qmd) and [Selectize (Multiple)](../selectize-multiple/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+
 ## Variations
 
 :::{#variations}

--- a/components/inputs/selectize-multiple/index.qmd
+++ b/components/inputs/selectize-multiple/index.qmd
@@ -72,6 +72,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<selectize_id>()` (e.g., `input.selectize()`) to access the selected value(s). The server value of a selectize list is a list of strings.
 
 See also: [Selectize (Single)](../selectize-single/index.qmd) and [Select (Multiple)](../select-multiple/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+## Variations
 
 :::{#variations}
 :::

--- a/components/inputs/selectize-multiple/index.qmd
+++ b/components/inputs/selectize-multiple/index.qmd
@@ -72,6 +72,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<selectize_id>()` (e.g., `input.selectize()`) to access the selected value(s). The server value of a selectize list is a list of strings.
 
 See also: [Selectize (Single)](../selectize-single/index.qmd) and [Select (Multiple)](../select-multiple/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+
 ## Variations
 
 :::{#variations}

--- a/components/inputs/selectize-single/index.qmd
+++ b/components/inputs/selectize-single/index.qmd
@@ -72,6 +72,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<selectize_id>()` (e.g., `input.selectize()`) to access the selected value. The server value of a selectize list is a list of strings. When `multiple=False`, this list will have length 1.
 
 See also: [Selectize (Multiple)](../selectize-multiple/index.qmd) and [Select (Single)](../select-single/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+## Variations
 
 :::{#variations}
 :::

--- a/components/inputs/selectize-single/index.qmd
+++ b/components/inputs/selectize-single/index.qmd
@@ -72,6 +72,7 @@ The value of an input component is accessible as a reactive value within the `se
   1. Use `input.<selectize_id>()` (e.g., `input.selectize()`) to access the selected value. The server value of a selectize list is a list of strings. When `multiple=False`, this list will have length 1.
 
 See also: [Selectize (Multiple)](../selectize-multiple/index.qmd) and [Select (Single)](../select-single/index.qmd). Select inputs and selectize inputs are similar, but have different interfaces and provide different ways of selecting multiple options. Selectize inputs also allow you to deselect items.
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/data-grid/index.qmd
+++ b/components/outputs/data-grid/index.qmd
@@ -136,6 +136,7 @@ The value returned will be `None` if no rows are selected, or a tuple of integer
 If your table is a data frame that uses the pandas styler, replace `ui.output_data_frame()` with `ui.output_table()` and `@render.data_frame` with `@render.table`.
 
 See also: [DataTables](../datatable/index.qmd)
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/data-grid/index.qmd
+++ b/components/outputs/data-grid/index.qmd
@@ -136,6 +136,7 @@ The value returned will be `None` if no rows are selected, or a tuple of integer
 If your table is a data frame that uses the pandas styler, replace `ui.output_data_frame()` with `ui.output_table()` and `@render.data_frame` with `@render.table`.
 
 See also: [DataTables](../datatable/index.qmd)
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/datatable/index.qmd
+++ b/components/outputs/datatable/index.qmd
@@ -138,6 +138,7 @@ The value returned will be `None` if no rows are selected, or a tuple of integer
 If your table is a data frame that uses the pandas styler, replace `ui.output_data_frame()` with `ui.output_table()` and `@render.data_frame` with `@render.table`.
 
 See also [Data Grids](../data-grid/index.qmd)
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/datatable/index.qmd
+++ b/components/outputs/datatable/index.qmd
@@ -138,6 +138,7 @@ The value returned will be `None` if no rows are selected, or a tuple of integer
 If your table is a data frame that uses the pandas styler, replace `ui.output_data_frame()` with `ui.output_table()` and `@render.data_frame` with `@render.table`.
 
 See also [Data Grids](../data-grid/index.qmd)
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/map-ipyleaflet/index.qmd
+++ b/components/outputs/map-ipyleaflet/index.qmd
@@ -79,6 +79,7 @@ To insert an `ipyleaflet` map do the following tasks:
   4. Register your map with shiny using `shinywidgets.register_widget()` by passing in the id of the map and the map variable.
 
  Visit [shiny.posit.co/py/docs/ipywidgets.html](https://shiny.posit.co/py/docs/ipywidgets.html) to learn more about using ipywidgets with Shiny.
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/map-ipyleaflet/index.qmd
+++ b/components/outputs/map-ipyleaflet/index.qmd
@@ -79,6 +79,7 @@ To insert an `ipyleaflet` map do the following tasks:
   4. Register your map with shiny using `shinywidgets.register_widget()` by passing in the id of the map and the map variable.
 
  Visit [shiny.posit.co/py/docs/ipywidgets.html](https://shiny.posit.co/py/docs/ipywidgets.html) to learn more about using ipywidgets with Shiny.
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/plot-matplotlib/index.qmd
+++ b/components/outputs/plot-matplotlib/index.qmd
@@ -113,6 +113,7 @@ You can use a plot as an input widget, collecting the locations of user clicks, 
   4. `brush` - When `brush = True`, the plot will allow the user to “brush” in the plotting area, and will send information about the brushed area to the server, where it can be accessed as a reactive variable named `input.<id>_brush()`, where `<id>` is the id of the plot. Brushing means that the user will be able to draw a rectangle in the plotting area and drag it around. The value will be a named list with xmin, xmax, ymin, and ymax elements indicating the brush area. To control the brush behavior, set `brush` to `brush_opts()`.
 
   Multiple `output_image()`/`output_plot()` calls may share the same id value; brushing one image or plot will cause any other brushes with the same id to disappear.
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/plot-matplotlib/index.qmd
+++ b/components/outputs/plot-matplotlib/index.qmd
@@ -99,7 +99,7 @@ in a [reactive fashion](https://shiny.posit.co/py/docs/reactive-programming.html
       - If you use the `@output()` decorator, make sure it is __above__ the `@render.plot()` decorator.
 
 
-## Plots as Inputs
+### Plots as Inputs
 
 
 You can use a plot as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, set one or more of the following arguments of `ui.output_plot()` to `True`:.
@@ -113,6 +113,7 @@ You can use a plot as an input widget, collecting the locations of user clicks, 
   4. `brush` - When `brush = True`, the plot will allow the user to “brush” in the plotting area, and will send information about the brushed area to the server, where it can be accessed as a reactive variable named `input.<id>_brush()`, where `<id>` is the id of the plot. Brushing means that the user will be able to draw a rectangle in the plotting area and drag it around. The value will be a named list with xmin, xmax, ymin, and ymax elements indicating the brush area. To control the brush behavior, set `brush` to `brush_opts()`.
 
   Multiple `output_image()`/`output_plot()` calls may share the same id value; brushing one image or plot will cause any other brushes with the same id to disappear.
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/plot-seaborn/index.qmd
+++ b/components/outputs/plot-seaborn/index.qmd
@@ -75,6 +75,7 @@ Follow these steps to display a Seaborn figure in your app:
       - If you use the `@output()` decorator, make sure it is __above__ the `@render.plot()` decorator.
 
 You can use a plot as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, follow the instructions provided for [plots as inputs](plot-matplotlib.html#plots-as-inputs).
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/plot-seaborn/index.qmd
+++ b/components/outputs/plot-seaborn/index.qmd
@@ -75,6 +75,7 @@ Follow these steps to display a Seaborn figure in your app:
       - If you use the `@output()` decorator, make sure it is __above__ the `@render.plot()` decorator.
 
 You can use a plot as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, follow the instructions provided for [plots as inputs](plot-matplotlib.html#plots-as-inputs).
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/text/index.qmd
+++ b/components/outputs/text/index.qmd
@@ -67,6 +67,7 @@ To make reactive text, follow three steps:
   3. Decorate the function with `@render.text`
 
 See [Verbatim Text](../verbatim-text/index.qmd) to display string values as they would appear in a computer console, in monospaced font on a shaded background.
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/text/index.qmd
+++ b/components/outputs/text/index.qmd
@@ -67,6 +67,7 @@ To make reactive text, follow three steps:
   3. Decorate the function with `@render.text`
 
 See [Verbatim Text](../verbatim-text/index.qmd) to display string values as they would appear in a computer console, in monospaced font on a shaded background.
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/ui/index.qmd
+++ b/components/outputs/ui/index.qmd
@@ -78,6 +78,7 @@ To add a UI output, follow three steps:
   3. Decorate the function with `@render.ui`. If you're using an action button or link to show the UI element, you'll also need to decorate with `@reactive.event`.
 
 See also: [Dynamic UI](https://shiny.posit.co/py/docs/ui-dynamic.html) and [UI and HTML](https://shiny.posit.co/py/docs/ui-html.html).
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/ui/index.qmd
+++ b/components/outputs/ui/index.qmd
@@ -78,6 +78,7 @@ To add a UI output, follow three steps:
   3. Decorate the function with `@render.ui`. If you're using an action button or link to show the UI element, you'll also need to decorate with `@reactive.event`.
 
 See also: [Dynamic UI](https://shiny.posit.co/py/docs/ui-dynamic.html) and [UI and HTML](https://shiny.posit.co/py/docs/ui-html.html).
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/value-box/index.qmd
+++ b/components/outputs/value-box/index.qmd
@@ -110,6 +110,7 @@ There is only a UI component for the value box.
 
 Since the value box is only a UI component, if you want to make it interactive (i.e., [reactive](https://shiny.posit.co/py/docs/reactive-programming.html)), you can pair it up with either a [`ui.output_ui()`](https://shiny.posit.co/py/api/ui.output_ui.html) + [`@render.ui()`](https://shiny.posit.co/py/api/render.ui.html) pair or use
 [`ui.output_text()`](https://shiny.posit.co/py/api/ui.output_text.html) as an argument to the `ui.value_box()` function if you only need text changes.
+## Variations
 
 :::{#variations}
 :::

--- a/components/outputs/value-box/index.qmd
+++ b/components/outputs/value-box/index.qmd
@@ -110,6 +110,7 @@ There is only a UI component for the value box.
 
 Since the value box is only a UI component, if you want to make it interactive (i.e., [reactive](https://shiny.posit.co/py/docs/reactive-programming.html)), you can pair it up with either a [`ui.output_ui()`](https://shiny.posit.co/py/api/ui.output_ui.html) + [`@render.ui()`](https://shiny.posit.co/py/api/render.ui.html) pair or use
 [`ui.output_text()`](https://shiny.posit.co/py/api/ui.output_text.html) as an argument to the `ui.value_box()` function if you only need text changes.
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/verbatim-text/index.qmd
+++ b/components/outputs/verbatim-text/index.qmd
@@ -63,6 +63,7 @@ To create reactive verbatim text, render the text in the server function with th
 By default, `ui.output_verbatim_text()` will display nothing when the string to display is empty. To ensure that `ui.output_verbatim_text()` displays an empty shaded rectangle as a placeholder even when when the string to display is empty, set `placeholder=True`.
 
 See [Text](../text/index.qmd) to display string values as normal text.
+
 ## Variations
 
 :::{#variations}

--- a/components/outputs/verbatim-text/index.qmd
+++ b/components/outputs/verbatim-text/index.qmd
@@ -63,6 +63,7 @@ To create reactive verbatim text, render the text in the server function with th
 By default, `ui.output_verbatim_text()` will display nothing when the string to display is empty. To ensure that `ui.output_verbatim_text()` displays an empty shaded rectangle as a placeholder even when when the string to display is empty, set `placeholder=True`.
 
 See [Text](../text/index.qmd) to display string values as normal text.
+## Variations
 
 :::{#variations}
 :::

--- a/layouts/_partials/layouts.css
+++ b/layouts/_partials/layouts.css
@@ -212,3 +212,14 @@ main a.nav-link:hover {
   border: 1px solid #e9ecef;
   border-radius: 10px;
 }
+
+/* Add rule and spacing between sections */
+section.level2:not(:first-child) h2 {
+  border-top: 1px solid var(--bs-primary);
+  padding-top: 5rem !important;
+  margin-top: 5rem !important;
+}
+
+section.level2:not(:first-child) > :last-child {
+  margin-bottom: 0;
+}

--- a/layouts/arrange/index.qmd
+++ b/layouts/arrange/index.qmd
@@ -42,8 +42,7 @@ Grid layouts can be used within a page, panel, or card and can even be nested wi
 ::: {#relevant-functions}
 :::
 
-::: {.border-bottom .blue .mt-6 .mb-5}
-:::
+
 
 ## Grid Layouts
 
@@ -123,8 +122,7 @@ There's a lot more that `layout_columns()` can do with `col_widths` to make high
 Learn more in the API reference: [Express](https://shiny.posit.co/py/api/express/ui.layout_columns.html) \| [Core](https://shiny.posit.co/py/api/core/ui.layout_columns.html)
 :::
 
-::: {.border-bottom .blue .mt-6 .mb-5}
-:::
+
 
 ### Uniform grid layouts
 
@@ -174,8 +172,7 @@ express_core_preview("app-column-nest-express.py", "app-column-nest-core.py")
 ```
 :::
 
-::: {.border-bottom .blue .mt-6 .mb-5}
-:::
+
 
 ## Controlling for page width and height
 

--- a/layouts/index.qmd
+++ b/layouts/index.qmd
@@ -21,11 +21,16 @@ format:
 :::::::: {.column-screen-inset .mx-auto style="max-width: 1300px;"}
 :::::: {.grid .hero-area .my-md-0 .my-5}
 :::: {.g-col-md-7 .g-col-12 .pe-0 .pe-md-5 .my-auto}
-::: {.display-3 .fw-bold}
-Shiny Layouts
+
+<h1 class="display-3 fw-bold">Shiny Layouts</h1>
+
+::: {.h5}
+Layouts allow the simplest or most complicated app to be useable and scalable.
+Is it bursting at the seams with content?
+Quickly change the layout for a fresh start.
+Fill these layouts with [Shiny Components](/components/index.qmd) to make your app reactive and interactive.
 :::
 
-##### Layouts allow the simplest or most complicated app to be useable and scalable.  Is it bursting at the seams with content? Quickly change the layout for a fresh start. Fill these layouts with [Shiny Components](/components/index.qmd) to make your app reactive and interactive.
 ::::
 :::: {.g-col-md-5 .g-col-10 .g-start-4 .components-hero-img-container}
 
@@ -47,11 +52,11 @@ Shiny Layouts
 :::: {.g-col-xl-3 .g-col-12}
 ::: {.sticky-xl-top .pt-4}
 
-<h3 class="mt-4">
+<h2 class="mt-4">
   <a href="navbars" class="dark text-decoration-none">
     <img src="/images/navbars-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Navbars
   </a>
-</h3>
+</h2>
 
 A navbar adds a navigation bar to your app, allowing users to easily navigate your app.
 
@@ -64,7 +69,7 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="navbars/#navbar-at-top">
-<h5>Navbar at Top</h5>
+<div class="h5">Navbar at Top</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="navbars/#navbar-at-top">
@@ -82,7 +87,7 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="navbars/#navbar-at-bottom">
-<h5>Navbar at Bottom</h5>
+<div class="h5">Navbar at Bottom</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="navbars/#navbar-at-bottom">
@@ -109,11 +114,11 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 ::: {.sticky-xl-top .pt-4}
 
 
-<h3 class="mt-4">
+<h2 class="mt-4">
   <a href="sidebars" class="dark text-decoration-none">
     <img src="/images/sidebars-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Sidebars
   </a>
-</h3>
+</h2>
 
 A sidebar layout creates a sidebar, typically used for inputs, and a large main area, typically used for outputs.
 
@@ -129,7 +134,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="sidebars/#sidebar-on-the-left">
-<h5>Sidebar on the Left</h5>
+<div class="h5">Sidebar on the Left</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="sidebars/#sidebar-on-the-left">
@@ -147,7 +152,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="sidebars/#sidebar-on-the-right">
-<h5>Sidebar on the Right</h5>
+<div class="h5">Sidebar on the Right</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="sidebars/#sidebar-on-the-right">
@@ -165,7 +170,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="sidebars/#sidebar-within-a-card">
-<h5>Sidebar Within a Card</h5>
+<div class="h5">Sidebar Within a Card</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="sidebars/#sidebar-within-a-card">
@@ -182,7 +187,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="sidebars/#collapsed-sidebar">
-<h5>Collapsed Sidebar</h5>
+<div class="h5">Collapsed Sidebar</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="sidebars/#collapsed-sidebar">
@@ -207,11 +212,11 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 ::: {.sticky-xl-top .pt-4}
 
 
-<h3 class="mt-4">
+<h2 class="mt-4">
   <a href="tabs" class="dark text-decoration-none">
     <img src="/images/tabs-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Tabs
   </a>
-</h3>
+</h2>
 
 Tabs and navigation allow you to create apps that have multiple pages.
 
@@ -226,7 +231,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="tabs/#tabset-with-pill-navigation">
-<h5>Tabset with Pill Nav</h5>
+<div class="h5">Tabset with Pill Nav</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="tabs/#tabset-with-pill-navigation">
@@ -244,7 +249,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="tabs/#tabset-with-pill-list-navigation">
-<h5>Tabset with Pill List Nav</h5>
+<div class="h5">Tabset with Pill List Nav</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="tabs/#tabset-with-pill-list-navigation">
@@ -261,7 +266,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="tabs/#tabset-with-tab-navigation">
-<h5>Tabset with Tab Nav</h5>
+<div class="h5">Tabset with Tab Nav</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="tabs/#tabset-with-tab-navigation">
@@ -279,8 +284,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="tabs/#card-with-a-tabbed-tabset">
-<h5>Card with a tabbed tabset
-</h5>
+<div class="h5">Card with a tabbed tabset</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="tabs/#card-with-a-tabbed-tabset">
@@ -298,7 +302,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="tabs/#card-with-a-pill-tabset">
-<h5>Card with a pill tabset</h5>
+<div class="h5">Card with a pill tabset</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="tabs/#card-with-a-pill-tabset">
@@ -315,7 +319,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="tabs/#vertically-collapsing-accordion-panels">
-<h5>Collapsing accordion panels</h5>
+<div class="h5">Collapsing accordion panels</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="tabs/#vertically-collapsing-accordion-panels">
@@ -338,11 +342,11 @@ Tabs and navigation allow you to create apps that have multiple pages.
 :::: {.g-col-xl-3 .g-col-12}
 ::: {.sticky-xl-top .pt-4}
 
-<h3 class="mt-4">
+<h2 class="mt-4">
   <a href="panels-cards" class="dark text-decoration-none">
     <img src="/images/cards-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Panels & Cards
   </a>
-</h3>
+</h2>
 
 Use panels and cards to define areas of related content.
 
@@ -357,7 +361,7 @@ Use panels and cards to define areas of related content.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="panels-cards/#main-image-with-panel-floating-above">
-<h5>Floating panel</h5>
+<div class="h5">Floating panel</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="panels-cards/#main-image-with-panel-floating-above">
@@ -375,7 +379,7 @@ Use panels and cards to define areas of related content.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="panels-cards/#content-divided-by-cards">
-<h5>Content in cards</h5>
+<div class="h5">Content in cards</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="panels-cards/#content-divided-by-cards">
@@ -401,11 +405,11 @@ Use panels and cards to define areas of related content.
 :::: {.g-col-xl-3 .g-col-12}
 ::: {.sticky-xl-top .pt-4}
 
-<h3 class="mt-4">
+<h2 class="mt-4">
   <a href="arrange" class="dark text-decoration-none">
     <img src="/images/arrange-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Arrange Elements
   </a>
-</h3>
+</h2>
 
 Use rows and columns to create your own layout for every device size.
 
@@ -421,7 +425,7 @@ Use rows and columns to create your own layout for every device size.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="arrange/#grid-layouts">
-<h5>Grid Layouts</h5>
+<div class="h5">Grid Layouts</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="arrange/#grid-layouts">
@@ -439,7 +443,7 @@ Use rows and columns to create your own layout for every device size.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="arrange/#column-nesting">
-<h5>Column nesting</h5>
+<div class="h5">Column nesting</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="arrange/#column-nesting">
@@ -457,7 +461,7 @@ Use rows and columns to create your own layout for every device size.
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
 <div class="component-list-header">
 <a class="component-list-header-text" href="arrange/#controlling-for-page-width-and-height">
-<h5>Control for page size</h5>
+<div class="h5">Control for page size</div>
 </a>
 <div class="component-list-icon">
 <p class="my-0"><a class="text-decoration-none dark" href="arrange/#controlling-for-page-width-and-height">

--- a/layouts/index.qmd
+++ b/layouts/index.qmd
@@ -54,7 +54,7 @@ Fill these layouts with [Shiny Components](/components/index.qmd) to make your a
 
 <h2 class="mt-4">
   <a href="navbars" class="dark text-decoration-none">
-    <img src="/images/navbars-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Navbars
+    <img alt="" src="/images/navbars-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Navbars
   </a>
 </h2>
 
@@ -78,7 +78,7 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="navbars/#navbar-at-top"><img src="/images/navbar-top.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="navbars/#navbar-at-top"><img alt="" src="/images/navbar-top.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -96,7 +96,7 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="navbars/#navbar-at-bottom"><img src="/images/navbar-bottom.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="navbars/#navbar-at-bottom"><img alt="" src="/images/navbar-bottom.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -116,7 +116,7 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 
 <h2 class="mt-4">
   <a href="sidebars" class="dark text-decoration-none">
-    <img src="/images/sidebars-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Sidebars
+    <img alt="" src="/images/sidebars-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Sidebars
   </a>
 </h2>
 
@@ -143,7 +143,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#sidebar-on-the-left"><img src="/images/sidebar-left.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#sidebar-on-the-left"><img alt="" src="/images/sidebar-left.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -161,7 +161,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#sidebar-on-the-right"><img src="/images/sidebar-right.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#sidebar-on-the-right"><img alt="" src="/images/sidebar-right.png" class="h-100 w-100"></a></p>
 
 </div>
 </div>
@@ -179,7 +179,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#sidebar-within-a-card"><img src="/images/sidebar-left-card.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#sidebar-within-a-card"><img alt="" src="/images/sidebar-left-card.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -196,7 +196,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#collapsed-sidebar"><img src="/images/sidebar-collapsed.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="sidebars/#collapsed-sidebar"><img alt="" src="/images/sidebar-collapsed.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -214,7 +214,7 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 
 <h2 class="mt-4">
   <a href="tabs" class="dark text-decoration-none">
-    <img src="/images/tabs-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Tabs
+    <img alt="" src="/images/tabs-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Tabs
   </a>
 </h2>
 
@@ -240,7 +240,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#tabset-with-pill-navigation"><img src="/images/tabset-pill.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#tabset-with-pill-navigation"><img alt="" src="/images/tabset-pill.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -258,7 +258,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#tabset-with-pill-list-navigation"><img src="/images/tabset-pill-list.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#tabset-with-pill-list-navigation"><img alt="" src="/images/tabset-pill-list.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -275,7 +275,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#tabset-with-tab-navigation"><img src="/images/tabset-tab.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#tabset-with-tab-navigation"><img alt="" src="/images/tabset-tab.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -293,7 +293,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#card-with-a-tabbed-tabset"><img src="/images/tabset-tab-card.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#card-with-a-tabbed-tabset"><img alt="" src="/images/tabset-tab-card.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -311,7 +311,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#card-with-a-pill-tabset"><img src="/images/tabset-pill-card.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#card-with-a-pill-tabset"><img alt="" src="/images/tabset-pill-card.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -328,7 +328,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#vertically-collapsing-accordion-panels"><img src="/images/accordion.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="tabs/#vertically-collapsing-accordion-panels"><img alt="" src="/images/accordion.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -344,7 +344,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 
 <h2 class="mt-4">
   <a href="panels-cards" class="dark text-decoration-none">
-    <img src="/images/cards-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Panels & Cards
+    <img alt="" src="/images/cards-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Panels & Cards
   </a>
 </h2>
 
@@ -370,7 +370,7 @@ Use panels and cards to define areas of related content.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="panels-cards/#main-image-with-panel-floating-above"><img src="/images/drag.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="panels-cards/#main-image-with-panel-floating-above"><img alt="" src="/images/drag.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -388,7 +388,7 @@ Use panels and cards to define areas of related content.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="component-list-header-text" href="panels-cards/#content-divided-by-cards"><img src="/images/two-cards.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="component-list-header-text" href="panels-cards/#content-divided-by-cards"><img alt="" src="/images/two-cards.png" class="h-100 w-100"></a></p>
 
 </div>
 </div>
@@ -407,7 +407,7 @@ Use panels and cards to define areas of related content.
 
 <h2 class="mt-4">
   <a href="arrange" class="dark text-decoration-none">
-    <img src="/images/arrange-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Arrange Elements
+    <img alt="" src="/images/arrange-blue.svg" class="me-2" style="height: 34px;margin-bottom:7px;">Arrange Elements
   </a>
 </h2>
 
@@ -434,7 +434,7 @@ Use rows and columns to create your own layout for every device size.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="arrange/#grid-layouts"><img src="/images/grid-layout.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="arrange/#grid-layouts"><img alt="" src="/images/grid-layout.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 
@@ -452,7 +452,7 @@ Use rows and columns to create your own layout for every device size.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="arrange/#column-nesting"><img src="/images/column-nesting.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="arrange/#column-nesting"><img alt="" src="/images/column-nesting.png" class="h-100 w-100"></a></p>
 
 </div>
 </div>
@@ -470,7 +470,7 @@ Use rows and columns to create your own layout for every device size.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="my-0 h-100 w-100"><a class="layout-list-image" href="arrange/#controlling-for-page-width-and-height"><img src="/images/controlling.png" class="h-100 w-100"></a></p>
+<p class="my-0 h-100 w-100"><a class="layout-list-image" href="arrange/#controlling-for-page-width-and-height"><img alt="" src="/images/controlling.png" class="h-100 w-100"></a></p>
 </div>
 </div>
 

--- a/layouts/navbars/index.qmd
+++ b/layouts/navbars/index.qmd
@@ -29,10 +29,6 @@ A navbar adds a navigation bar to your app, allowing users to easily navigate yo
 :::{#relevant-functions}
 :::
 
-:::{.border-bottom .blue .mt-6 .mb-5}
-:::
-
-
 ## Navbar at top
 
 :::{.column-screen-inset-right style="max-width:800px;"}
@@ -57,8 +53,7 @@ Follow these steps to add a navbar to the top of your app:
 
   4. _Optional:_ Pass a string to the `id` argument of `ui.page_navbar()`. This will create an input value that holds the title of the currently selected nav item. For example, `id = "tab"` would create a reactive value accessible as `input.tab()`.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Navbar at bottom
 

--- a/layouts/panels-cards/index.qmd
+++ b/layouts/panels-cards/index.qmd
@@ -44,6 +44,7 @@ Use panels and cards to define areas of related content.
 
 :::{#relevant-functions}
 :::
+
 ## Floating panel
 
 :::{.column-screen-inset-right style="max-width:800px;"}

--- a/layouts/panels-cards/index.qmd
+++ b/layouts/panels-cards/index.qmd
@@ -44,10 +44,6 @@ Use panels and cards to define areas of related content.
 
 :::{#relevant-functions}
 :::
-
-:::{.border-bottom .blue .mt-6 .mb-5}
-:::
-
 ## Floating panel
 
 :::{.column-screen-inset-right style="max-width:800px;"}
@@ -80,8 +76,7 @@ You can also use `ui.img()` to create this effect:
 
 See also: [`ui.panel_fixed()`](https://shiny.posit.co/py/api/ui.panel_fixed.html). `ui.panel_fixed()` is equivalent to calling `ui.panel_absolute()` with `fixed=True` (i.e., the panel does not scroll with the rest of the page).
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Content divided by cards
 

--- a/layouts/sidebars/index.qmd
+++ b/layouts/sidebars/index.qmd
@@ -31,10 +31,6 @@ A sidebar layout creates a sidebar, typically used for inputs, and a large main 
 ::: {#relevant-functions}
 :::
 
-
-:::{.border-bottom .blue .mt-6 .mb-5}
-:::
-
 ## Sidebar on the left
 
 :::{.column-screen-inset-right style="max-width:800px;"}
@@ -57,8 +53,7 @@ Follow these steps to add a left-side sidebar to your app:
 
   3. Supply additional components (output components, cards, text, etc.) to `ui.layout_sidebar()` to define the contents of the main content area.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Sidebar on the right
 
@@ -85,8 +80,7 @@ Follow these steps to add a right-side sidebar to your app:
 
   3. Supply components (e.g., inputs) to `ui.sidebar()` to define the sidebar's contents. Supply additional components (e.g., output components, cards, etc.) to `ui.layout_sidebar()` to define the contents of the main content area.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Sidebar within a card
 
@@ -110,8 +104,7 @@ Follow these steps to add a sidebar within a card to your app:
   3. Add `ui.sidebar()` and additional elements to `ui.layout_sidebar()` to define the sidebar and main content as usual.
   4. Add inputs or other components as desired to `ui.sidebar()` to define the sidebar's contents.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Collapsed sidebar
 

--- a/layouts/tabs/index.qmd
+++ b/layouts/tabs/index.qmd
@@ -48,6 +48,7 @@ Tabs and navigation allow you to create apps that have multiple pages.
 
 ::: {#relevant-functions}
 :::
+
 ## Tabset with pill navigation
 
 :::{.column-screen-inset-right style="max-width:800px;"}

--- a/layouts/tabs/index.qmd
+++ b/layouts/tabs/index.qmd
@@ -48,10 +48,6 @@ Tabs and navigation allow you to create apps that have multiple pages.
 
 ::: {#relevant-functions}
 :::
-
-:::{.border-bottom .blue .mt-6 .mb-5}
-:::
-
 ## Tabset with pill navigation
 
 :::{.column-screen-inset-right style="max-width:800px;"}
@@ -76,8 +72,7 @@ Follow these steps to create an app with a tabset with pill navigation layout:
 
   4. _Optional:_ Pass a string to the `id` argument of `ui.navset_pill()`. This will create an input value that holds the title of the currently selected nav item. For example, `id = "tab"` would create a reactive value accessible as `input.tab()`.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Tabset with pill list navigation
 
@@ -101,8 +96,7 @@ Follow these steps to create an app with a pill list navigation layout. A pill l
 
   4. _Optional:_ Pass a string to the `id` argument of `ui.navset_pill_list()`. This will create an input value that holds the title of the currently selected nav item. For example, `id = "tab"` would create a reactive value accessible as `input.tab()`.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Tabset with tab navigation
 
@@ -126,8 +120,7 @@ Follow these steps to create an app with a tab navigation layout:
 
   4. _Optional:_ Pass a string to the `id` argument of `ui.navset_tab()`. This will create an input value that holds the title of the currently selected nav item. For example, `id = "tab"` would create a reactive value accessible as `input.tab()`.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Card with a tabbed tabset
 
@@ -151,8 +144,7 @@ Follow these steps to add a card with a tabbed tabset to your app:
 
   4. _Optional:_ Pass a string to the `id` argument of `ui.navset_card_tab()`. This will create an input value that holds the title of the currently selected nav item. For example, `id = "tab"` would create a reactive value accessible as `input.tab()`.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Card with a pill tabset
 
@@ -176,8 +168,7 @@ Follow these steps to add a card with a pill tabset to your app:
 
   4. _Optional:_ Pass a string to the `id` argument of `ui.navset_card_pill()`. This will create an input value that holds the title of the currently selected nav item. For example, `id = "tab"` would create a reactive value accessible as `input.tab()`.
 
-:::{.border-bottom .blue .my-5}
-:::
+
 
 ## Vertically collapsing accordion panels
 


### PR DESCRIPTION
Restores the missing **Variations** heading in the components gallery.

Also switches to using CSS to add the section dividers and spacing via `border-top` on `h2` elements, except the first `h2` on the page. This works for both `components/` and `layouts/`.

I also made sure that sections in `components/` that are below `## Details` are level-3 headings (e.g. `### Another detail`) so they fit in the Details section.

While looking at the headings, I noticed that there were just heading jumps (e.g. an `<h5>` nested inside an `<h2>`). I updated the heading structure to use `h1` through `h3`. Most of the `<h5>` elements were used for styling, so I switched these out for `<div class="h5">` to get the same affect without putting the element in the accessibility tree.

While looking at that (using the [axe DevTools extension](https://www.deque.com/axe/devtools/)) I found a few images that are primarily decorative that were missing `alt=""` attributes.