### PR TITLE
Use lower-case `reactive.calc`, `.effect`, and `.value`

### DIFF
--- a/components/display-messages/modal/index.qmd
+++ b/components/display-messages/modal/index.qmd
@@ -69,7 +69,7 @@ To create a modal, first assemble the components of the modal with [`ui.modal()`
 Typically, you will want to create a reactive effect to call `ui.modal_show()` whenever a particular event occurs. For example, the reactive effect below will open a modal whenever the value of `input.show()` changes.
 
 ```python
-@reactive.Effect
+@reactive.effect
 @reactive.event(input.show)
 def _():
     m = ui.modal( #<<

--- a/components/display-messages/notifications/app-preview.py
+++ b/components/display-messages/notifications/app-preview.py
@@ -13,7 +13,7 @@ def server(input, output, session):
     ids: list[str] = []
     n: int = 0
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.show)
     def _():
         nonlocal ids
@@ -23,7 +23,7 @@ def server(input, output, session):
         ids.append(id)
         n += 1
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.remove)
     def _():
         nonlocal ids

--- a/components/display-messages/notifications/app-variation-replace-update-a-notification-core.py
+++ b/components/display-messages/notifications/app-variation-replace-update-a-notification-core.py
@@ -6,7 +6,7 @@ app_ui = ui.page_fluid(
 
 
 def server(input, output, session):
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.show)
     def show_or_update_notification():
         ui.notification_show(

--- a/components/display-messages/notifications/app-variation-track-and-remove-notifications-core.py
+++ b/components/display-messages/notifications/app-variation-track-and-remove-notifications-core.py
@@ -10,7 +10,7 @@ def server(input, output, session):
     ids: list[str] = []
     n: int = 0
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.show)
     def _():
         nonlocal ids
@@ -22,7 +22,7 @@ def server(input, output, session):
         ids.append(id)
         n += 1
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.remove)
     def _():
         nonlocal ids

--- a/components/display-messages/notifications/app-variation-track-and-remove-notifications-express.py
+++ b/components/display-messages/notifications/app-variation-track-and-remove-notifications-express.py
@@ -8,7 +8,7 @@ ids: list[str] = []
 n: int = 0
 
 
-@reactive.Effect
+@reactive.effect
 @reactive.event(input.show)
 def _():
     global ids
@@ -19,7 +19,7 @@ def _():
     n += 1
 
 
-@reactive.Effect
+@reactive.effect
 @reactive.event(input.remove)
 def _():
     global ids

--- a/components/display-messages/notifications/index.qmd
+++ b/components/display-messages/notifications/index.qmd
@@ -78,7 +78,7 @@ A notification is a message that appears near the bottom corner of the app. Noti
 To create a notification, call [`ui.notification_show()`](https://shiny.posit.co/py/api/ui.notification_show.html). Typically, you will want to create a reactive effect to call `ui.show_notification()` whenever a particular event occurs. For example, the reactive effect below will create a notification whenever the value of `input.show()` changes.
 
 ```{.python}
-@reactive.Effect
+@reactive.effect
 @reactive.event(input.show)
 def _():
     ui.notification_show("You've been notified.")

--- a/components/inputs/action-button/app-detail-preview.py
+++ b/components/inputs/action-button/app-detail-preview.py
@@ -11,9 +11,9 @@ app_ui = ui.page_fluid(
 
 
 def server(input, output, session):
-    count = reactive.Value(0)
+    count = reactive.value(0)
 
-    @reactive.Effect
+    @reactive.effect
     @reactive.event(input.action_button)
     def _():
         count.set(count() + 1)

--- a/docs/apps/comp-streamlit/penguins/app-core.py
+++ b/docs/apps/comp-streamlit/penguins/app-core.py
@@ -19,7 +19,7 @@ def server(input, output, session):
     df = load_penguins()
     print(df)
 
-    @reactive.Calc
+    @reactive.calc
     def filtered_data():
         filt_df = df.copy()
         filt_df = filt_df.loc[df["body_mass_g"] < input.mass()]

--- a/docs/apps/comp-streamlit/penguins/app-express.py
+++ b/docs/apps/comp-streamlit/penguins/app-express.py
@@ -13,7 +13,7 @@ with ui.sidebar():
     ui.input_checkbox("smoother", "Add Smoother")
 
 
-@reactive.Calc
+@reactive.calc
 def filtered_data():
     filt_df = df.copy()
     filt_df = filt_df.loc[df["body_mass_g"] < input.mass()]


### PR DESCRIPTION
This PR updates examples to use lower-case  `reactive.calc`, `.effect`, and `.value`.