### PR TITLE
Update to shinylive 0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.2.3
+shinylive==0.2.4
 matplotlib==3.8.1
 shiny
 seaborn==0.13.0


### PR DESCRIPTION
This updates to shinylive 0.2.4, so that it will have Shiny 0.8.1 in shinylive.