### PR TITLE
Open template link in same browser tab

### DIFF
--- a/templates/_partials/template-listing.ejs
+++ b/templates/_partials/template-listing.ejs
@@ -3,7 +3,7 @@
 <% for (const item of items) { %>
 ```{=html}
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
-  <a class="component-list-header-text" href="<%= item.path %>/" target="_blank">
+  <a class="component-list-header-text" href="<%= item.path %>/">
     <div class="component-list-header">
       <div class="h5"><%= item.title %></div>
       <div class="component-list-icon">


### PR DESCRIPTION
Removes the `target="_blank"` so that links to a template in the template gallery don't open in a new browser tab.