### PR TITLE
Remove Source code positioning rule

### DIFF
--- a/quarto-style.scss
+++ b/quarto-style.scss
@@ -1857,11 +1857,6 @@ btn.action-button:hover {
   border: none;
 }
 
-/* improve position of code copy button */
-div.sourceCode > pre.sourceCode {
-  position: static;
-}
-
 .code-with-filename {
   position: relative;
 }


### PR DESCRIPTION
This rule was added in the Express changes, but seems to have removed the copy button from regular code chunks (e.g https://shiny.posit.co/py/docs/comp-r-shiny.html#r)