### PR TITLE
Update app-two-cards-express.py

### DIFF
--- a/layouts/panels-cards/app-two-cards-express.py
+++ b/layouts/panels-cards/app-two-cards-express.py
@@ -1,4 +1,4 @@
-from shiny import ui
+from shiny.express import ui
 
 ui.page_opts(fillable=True)
 


### PR DESCRIPTION
Update module import from "shiny" to "shiny.express".

Fixes the following error when running the example: `RuntimeError: module 'shiny.ui' has no attribute 'page_opts'`