### PR TITLE
Update py-shiny and py-shinylive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.3.0
+shinylive==0.4.0
 matplotlib==3.8.1
 shiny
 seaborn==0.13.0


### PR DESCRIPTION
This PR updates py-shiny to 0.10.1 for API docs, and py-shinylive to 0.4.0.