### PR TITLE
Update shiny-vscode link

### DIFF
--- a/docs/custom-components-pkg.qmd
+++ b/docs/custom-components-pkg.qmd
@@ -78,7 +78,7 @@ While there are lots of ways to develop components with live-feedback (e.g. Stor
 
 2. Run the bundler in watch mode with `npm run watch`. This will watch the `srcts` directory for changes and automatically rebuild the JavaScript when it detects a change.
 
-3. Run the example app in live-reload mode. If you're using VScode, the [Shiny for Python extension](https://marketplace.visualstudio.com/items?itemName=Posit.shiny-python) enables this automatically when pressing the run button above the app script.
+3. Run the example app in live-reload mode. If you're using VScode, the [Shiny extension](https://marketplace.visualstudio.com/items?itemName=Posit.shiny) enables this automatically when pressing the run button above the app script.
 
 Now you can update your component JavaScript/python functions and your app will automatically reload with the changes. Happy developing!
 

--- a/docs/install-create-run.qmd
+++ b/docs/install-create-run.qmd
@@ -130,7 +130,7 @@ You can also modify these settings on a per-file basis with comments at the top 
 A full list of configuration settings for Pyright/Pylance is available [here](https://github.com/microsoft/pyright/blob/main/docs/configuration.md).
 
 [vscode]: https://code.visualstudio.com/
-[vscode-shiny]: https://marketplace.visualstudio.com/items?itemName=posit.shiny-python
+[vscode-shiny]: https://marketplace.visualstudio.com/items?itemName=posit.shiny
 [vscode-python]: https://marketplace.visualstudio.com/items?itemName=ms-python.python
 :::
 
@@ -158,7 +158,7 @@ Shiny apps can be launched from VSCode or the command line (via `shiny run`).
 
 ### VS Code
 
-The best way to run (and develop) Shiny apps is in [Visual Studio Code][vscode] with the [Shiny for Python extension][vscode-shiny]. When a Shiny `app.py` file is being edited, the default behavior of the Run button (circled in red in the screenshot below) becomes "Run Shiny App".
+The best way to run (and develop) Shiny apps is in [Visual Studio Code][vscode] with the [Shiny extension][vscode-shiny]. When a Shiny `app.py` file is being edited, the default behavior of the Run button (circled in red in the screenshot below) becomes "Run Shiny App".
 
 ![Visual Studio Code running with the Shiny extension](assets/vscode.png)
 


### PR DESCRIPTION
Updates the link to the `Posit.shiny` VS Code extension. See https://shiny.posit.co/blog/posts/shiny-vscode-1.0.0/ for more details.