### PR TITLE
Disable busy indication in static previews

### DIFF
--- a/components/make-static-previews.py
+++ b/components/make-static-previews.py
@@ -80,6 +80,8 @@ def enrich_app_ui(app_ui: Tag):
     being intialized as part of the Shiny binding process.
     """
     app_ui.append(shiny.html_dependencies.shiny_deps())
+    # Don't ever show busy indication since these are static previews
+    app_ui.append(shiny.ui.busy_indicators.use(spinners=False, pulse=False))
     app_ui.append(
         head_content(
             tags.script(


### PR DESCRIPTION
This PR gets rid of the spinners in the input section of https://shiny.posit.co/py/components/ that never go away


https://github.com/posit-dev/py-shiny-site/assets/1365941/857b3c58-516c-4825-b8e7-920e3e2bfcdb

