### PR TITLE
Enable fast mode

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -40,6 +40,7 @@ filters:
   - interlinks
 
 interlinks:
+  fast: true
   sources:
     python:
       url: https://docs.python.org/3/


### PR DESCRIPTION
This has two effects: making the build faster, as quarto render currently uses a slow Lua JSON parser to deserialize objects.json on every page render; and generating an objects.txt file, which can be used by sphinx so that downstream projects can interlink with us.