### PR TITLE
feat: Enable repo-actions

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -62,6 +62,9 @@ website:
     image-height: 630
     card-style: "summary_large_image"
 
+  repo-url: https://github.com/posit-dev/py-shiny-site
+  repo-actions: [issue, edit]
+
   navbar:
     background: primary
     foreground: light

--- a/components/_metadata.yml
+++ b/components/_metadata.yml
@@ -10,3 +10,4 @@ filters:
   - quarto
   - line-highlight
   - shinylive
+repo-actions: false

--- a/gallery/_metadata.yml
+++ b/gallery/_metadata.yml
@@ -1,0 +1,1 @@
+repo-actions: false

--- a/index.qmd
+++ b/index.qmd
@@ -11,6 +11,7 @@ format:
     smooth-scroll: true
     css:
       - index.css
+repo-actions: false
 ---
 
 ::::{.column-screen .mx-auto .pt-0 .mt-0 .pt-xl-5  style="max-width: 1500px;"}

--- a/layouts/_metadata.yml
+++ b/layouts/_metadata.yml
@@ -1,7 +1,7 @@
 sidebar: layouts
 format:
   html:
-    css: 
+    css:
       - /components/_partials/components.css
       - _partials/layouts-list.css
     toc: false
@@ -10,5 +10,6 @@ format:
 filters:
   - quarto
   - line-highlight
-  - shinylive 
- 
+  - shinylive
+
+repo-actions: false

--- a/templates/_metadata.yml
+++ b/templates/_metadata.yml
@@ -3,12 +3,13 @@ format:
   html:
     template: _partials/gallery-article.template
     page-layout: article
-    css: 
+    css:
       - /components/_partials/components.css
       - _partials/templates.css
     toc: false
     code-line-numbers: false
     include-after-body: ../components/_partials/componentsjs.html
 filters:
-  - shinylive 
- 
+  - shinylive
+
+repo-actions: false


### PR DESCRIPTION
Adds repo actions to articles, reference pages, etc.

![image](https://github.com/user-attachments/assets/eaee6aa2-aa98-49b2-95f9-b953bc406aa2)


Repo actions can be disabled on pages or in subdirectories by adding `repo-actions: false` to the page frontmatter or to `_metadata.yml` in a directory.

[More information in Quarto's docs](https://quarto.org/docs/websites/website-navigation.html#github-links).