### PR TITLE
bug(py-shiny): Fix examples missing supporting files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ quarto-exts:
 deps: $(PYBIN)
 	$(PYBIN)/pip install pip --upgrade
 	$(PYBIN)/pip install -r requirements.txt
-	. $(PYBIN)/activate && cd py-shiny && make install-deps
-	. $(PYBIN)/activate && cd py-shiny/docs && make deps
+	. $(PYBIN)/activate && cd py-shiny && make install-docs
 
 ## Build qmd files for Shiny API docs
 quartodoc: $(PYBIN)


### PR DESCRIPTION
Fixes https://github.com/posit-dev/py-shiny-site/issues/181
Fixes https://github.com/posit-dev/py-shiny-site/issues/191
Fixes https://github.com/posit-dev/py-shiny/issues/1568

This addresses py-shiny-site installing into `venv` which was causing the example supporting files to be removed. 

- [x] Looking into why files in `venv` are being removed