### PR TITLE
Pin pydeck to 0.8.0

### DIFF
--- a/docs/jupyter-widgets.qmd
+++ b/docs/jupyter-widgets.qmd
@@ -35,7 +35,7 @@ Then, install the ipywidgets that you'd like to use.
 For this article, we'll need the following:
 
 ```bash
-pip install altair bokeh plotly pydeck ipyleaflet
+pip install altair bokeh plotly ipyleaflet pydeck==0.8.0
 ```
 
 ## Get started {#get-started}
@@ -182,7 +182,7 @@ def map():
     # Combined all of it and render a viewport
     return pdk.Deck(layers=[layer], initial_view_state=view_state)
 ## file: requirements.txt
-pydeck
+pydeck==0.8.0
 ```
 
 ##### Other

--- a/docs/overview.qmd
+++ b/docs/overview.qmd
@@ -269,7 +269,7 @@ def map():
     # Combined all of it and render a viewport
     return pdk.Deck(layers=[layer], initial_view_state=view_state)
 ## file: requirements.txt
-pydeck
+pydeck==0.8.0
 ```
 
 ##### Other


### PR DESCRIPTION
The pydeck v0.9 has (hopefully temporarily) removed it's ipywidgets support (https://github.com/visgl/deck.gl/pull/8854). 

Long term, we may want to consider bundling v0.8.0 with shinylive (especially if they don't ever bring ipywidgets support back), but this is a more immediate fix for pydeck examples in the docs