### PR TITLE
Install quarto before installing R dependencies

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,6 +39,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          install-quarto: false
           packages: |
             any::knitr
             any::rmarkdown

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           make submodules
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: 1.4.557
+
       - name: Install R
         uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -47,10 +51,6 @@ jobs:
       # =====================================================
       # Build
       # =====================================================
-      - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: 1.4.557
-
       - name: Build site
         run: |
           make all


### PR DESCRIPTION
We have a `Run quarto-dev/quarto-actions/setup@v2` step with the version specified. However, the `r-lib/actions/setup-r-dependencies@v2` step in the workflow was indirectly causing another copy of `Run quarto-dev/quarto-actions/setup@v2` to run, but without a version specified. This installation failed because the system doesn't want to downgrade the .deb package.

https://github.com/posit-dev/py-shiny-site/actions/runs/10250692524/job/28356982088#step:9:2457

