### PR TITLE
fix: links to localhost

### DIFF
--- a/templates/dashboard/index.qmd
+++ b/templates/dashboard/index.qmd
@@ -24,26 +24,26 @@ shiny create -m core \
 
 A basic dashboard with input filters, value boxes, a plot, and table.
 This particular dashboard visualizes [the `palmerpenguins` dataset](https://github.com/mcnakhaee/palmerpenguins).
-In addition to demonstrating the basics visual components of a dashboard, it also demonstrates how to leverage [reactive calculations](http://localhost:1414/docs/reactive-foundations.html#calculations) to filter the data once and use it as needed in multiple places.
+In addition to demonstrating the basics visual components of a dashboard, it also demonstrates how to leverage [reactive calculations](../../docs/reactive-foundations.qmd#calculations) to filter the data once and use it as needed in multiple places.
 
 :::: {.grid .tags}
 
 ::: {.g-col-6 .g-col-sm-4}
 **Components:**
 
-* [Slider input](/components/inputs/slider)
-* [Checkbox group input](/components/inputs/checkbox-group)
-* [Value box](/components/outputs/value-box)
-* [Plot output](/components/outputs/plot-seaborn)
-* [Data grid output](/components/outputs/data-grid)
+* [Slider input](../../components/inputs/slider/index.qmd)
+* [Checkbox group input](../../components/inputs/checkbox-group/index.qmd)
+* [Value box](../../components/outputs/value-box/index.qmd)
+* [Plot output](../../components/outputs/plot-seaborn/index.qmd)
+* [Data grid output](../../components/outputs/data-grid/index.qmd)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}
 **Layouts:**
 
-* [Sidebar](https://shiny.posit.co/py/layouts/sidebars)
-* [Grid layout](http://localhost:1414/layouts/arrange)
-* [Cards](/layouts/panels-cards/#content-divided-by-cards)
+* [Sidebar](../../layouts/sidebars/index.qmd)
+* [Grid layout](../../layouts/arrange/index.qmd)
+* [Cards](../../layouts/panels-cards/index.qmd#content-divided-by-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}


### PR DESCRIPTION
Fixes two links to localhost that were included by accident during development.

Also makes links relative and uses links directly to the `.qmd` file. I recommend we use this approach moving forward, as Quarto handles these links directly and it makes it much easier to move around in the source files. 

```markdown
<!-- opens components/inputs/slider in the browser pane -->
* [Slider input](/components/inputs/slider)

<!-- opens the source file for the slider component -->
* [Slider input](../../components/inputs/slider/index.qmd)
```