### PR TITLE
fix: retitle basic-sidebar template

### DIFF
--- a/templates/basic-sidebar/index.qmd
+++ b/templates/basic-sidebar/index.qmd
@@ -1,5 +1,5 @@
 ---
-title:        "Reactive plot in sidebar"
+title:        "Reactive plot with a sidebar"
 description:  Use the basic-sidebar template as a foundation for your next Shiny app.
 date:         2024-03-04
 image:        thumbnail.png


### PR DESCRIPTION
From "Reactive plot in a sidebar" (sounds like the plot shows up in a sidebar) to "Reactive plot **with a** sidebar".