### PR TITLE
temp: work around griffe v1.0.0 changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ plotly
 shinywidgets
 ipyleaflet==0.17.4
 favicons
+griffe<1.0.0 # FIXME remove after posit-dev/py-shiny#1636


### PR DESCRIPTION
Works around griffe v1.0.0 changes using same approach as https://github.com/posit-dev/py-shiny/pull/1627

Watch https://github.com/posit-dev/py-shiny/pull/1636 for Shiny using quartodoc 0.7.6