### PR TITLE
bug: Checkout full py-shiny repo when initing submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ help:
 ## Update git submodules to commits referenced in this repository
 submodules:
 	git submodule init
-	git submodule update --depth=20
+	git submodule update --depth=0
 
 ## Pull latest commits in git submodules
 submodules-pull:


### PR DESCRIPTION
Seen in https://github.com/posit-dev/py-shiny-site/actions/runs/11245305450/job/31265057161?pr=221#step:9:765 from https://github.com/posit-dev/py-shiny-site/pull/221