### PR TITLE
Pin ridgeplot to 0.1.25

### DIFF
--- a/docs/express-or-core.qmd
+++ b/docs/express-or-core.qmd
@@ -262,7 +262,7 @@ def server(input, output, session):
 app = App(app_ui, server)
 
 ## file: requirements.txt
-ridgeplot
+ridgeplot==0.1.25
 ```
 
 :::

--- a/docs/user-interfaces.qmd
+++ b/docs/user-interfaces.qmd
@@ -387,7 +387,7 @@ def _():
     ui.update_checkbox_group("time", selected=["Lunch", "Dinner"])
 
 ## file: requirements.txt
-ridgeplot
+ridgeplot==0.1.25
 ```
 
 :::


### PR DESCRIPTION
Recent versions of ridgeplot started [requiring `statsmodels!=0.14.2`](https://github.com/tpvasconcelos/ridgeplot/commit/568caa3d72aac3a18ee6ceb8f32de112b2bf8454#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R44), which is exactly the version that currently gets [bundled with pyodide](https://pyodide.org/en/stable/usage/packages-in-pyodide.html). 

So, as workaround, we just pin the version for shinylive to version of ridgeplot just before that requirement was added (and the examples work fine)