### PR TITLE
Improve reference to shiny_validate

### DIFF
--- a/quarto-style.scss
+++ b/quarto-style.scss
@@ -1622,10 +1622,17 @@ code .parameter-default a {
 }
 
 .tags li a:not(.tags li code) {
-font-weight: 600 !important;
-text-transform: uppercase;
-font-size: .75rem;
-padding-bottom: .125rem;
+  font-weight: 600 !important;
+  text-transform: uppercase;
+  font-size: .75rem;
+  padding-bottom: .125rem;
+}
+
+.tags li a code {
+  color: shade-color($primary, 13%);
+  font-weight: 400;
+  font-size: 0.855rem;
+  text-transform: lowercase;
 }
 
 /*.tag.badge.text-bg-light {

--- a/templates/survey-wizard/index.qmd
+++ b/templates/survey-wizard/index.qmd
@@ -19,7 +19,7 @@ shiny create --template survey-wizard --mode core --github posit-dev/py-shiny-te
 
 
 A simple survey wizard that simply writes responses to a file and displays a confirmation message when submitted.
-In this example, we use the `shiny_validate` package for input validation, providing direct feedback when the user enters invalid responses.
+In this example, we use the [shiny_validate] package for input validation, providing direct feedback when the user enters invalid responses.
 We also make clever use of [`navset_hidden()`](/api/core/ui.navset_hidden.qmd) to show/hide different steps of the form via action buttons.
 
 
@@ -46,7 +46,10 @@ We also make clever use of [`navset_hidden()`](/api/core/ui.navset_hidden.qmd) t
 **Packages:**
 
 * `pandas`
-* `shiny_validate`
+* [shiny_validate]
 
 :::
 ::::
+
+
+[shiny_validate]: https://github.com/posit-dev/py-shiny-validate

--- a/templates/survey-wizard/index.qmd
+++ b/templates/survey-wizard/index.qmd
@@ -19,7 +19,8 @@ shiny create --template survey-wizard --mode core --github posit-dev/py-shiny-te
 
 
 A simple survey wizard that simply writes responses to a file and displays a confirmation message when submitted.
-In this example, we use the `shiny_validate` package to validate the form inputs, and make clever use of [`navset_hidden()`](/api/core/ui.navset_hidden.qmd) to show/hide different steps of the form via action buttons.
+In this example, we use the `shiny_validate` package for input validation, providing direct feedback when the user enters invalid responses.
+We also make clever use of [`navset_hidden()`](/api/core/ui.navset_hidden.qmd) to show/hide different steps of the form via action buttons.
 
 
 :::: {.grid .tags}

--- a/templates/survey-wizard/index.qmd
+++ b/templates/survey-wizard/index.qmd
@@ -46,7 +46,7 @@ We also make clever use of [`navset_hidden()`](/api/core/ui.navset_hidden.qmd) t
 **Packages:**
 
 * `pandas`
-* [shiny_validate]
+* [`shiny_validate`][shiny_validate]
 
 :::
 ::::

--- a/templates/survey/index.qmd
+++ b/templates/survey/index.qmd
@@ -23,7 +23,7 @@ shiny create --template survey --mode core --github posit-dev/py-shiny-templates
 
 
 A simple survey form with a few input fields that simply writes responses to a file and displays a confirmation message when submitted.
-In this example, we use the `shiny_validate` package for input validation, providing direct feedback when the user enters invalid responses.
+In this example, we use the [shiny_validate] package for input validation, providing direct feedback when the user enters invalid responses.
 
 
 :::: {.grid .tags}
@@ -49,7 +49,9 @@ In this example, we use the `shiny_validate` package for input validation, provi
 **Packages:**
 
 * `pandas`
-* `shiny_validate`
+* [shiny_validate]
 
 :::
 ::::
+
+[shiny_validate]: https://github.com/posit-dev/py-shiny-validate

--- a/templates/survey/index.qmd
+++ b/templates/survey/index.qmd
@@ -49,9 +49,9 @@ In this example, we use the [shiny_validate] package for input validation, provi
 **Packages:**
 
 * `pandas`
-* [`shiny_validate`]
+* [`shiny_validate`][shiny_validate]
 
 :::
 ::::
 
-[`shiny_validate`]: https://github.com/posit-dev/py-shiny-validate
+[shiny_validate]: https://github.com/posit-dev/py-shiny-validate

--- a/templates/survey/index.qmd
+++ b/templates/survey/index.qmd
@@ -49,9 +49,9 @@ In this example, we use the [shiny_validate] package for input validation, provi
 **Packages:**
 
 * `pandas`
-* [shiny_validate]
+* [`shiny_validate`]
 
 :::
 ::::
 
-[shiny_validate]: https://github.com/posit-dev/py-shiny-validate
+[`shiny_validate`]: https://github.com/posit-dev/py-shiny-validate

--- a/templates/survey/index.qmd
+++ b/templates/survey/index.qmd
@@ -23,7 +23,7 @@ shiny create --template survey --mode core --github posit-dev/py-shiny-templates
 
 
 A simple survey form with a few input fields that simply writes responses to a file and displays a confirmation message when submitted.
-In this example, we use the `shiny_validate` package to validate the form inputs.
+In this example, we use the `shiny_validate` package for input validation, providing direct feedback when the user enters invalid responses.
 
 
 :::: {.grid .tags}


### PR DESCRIPTION
Improve the link from our docs to shiny_validate, as pointed out by #238

- Use phrase "input validation" when describing shiny_validate
- Link directly to shiny_validate


