### PR TITLE
Improved sidebar styling for 'Learn Shiny'

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -232,49 +232,49 @@ website:
       collapse-level: 2
       align: left
       contents:
-        - section: "Essentials"
+        - section: "<span class='emoji-icon'>📌</span>  __Essentials__"
           contents:
             - docs/overview.qmd
             - docs/user-interfaces.qmd
-        - section: "Workflow"
+        - section: "<span class='emoji-icon'>💻</span>  __Workflow__"
           contents:
             - docs/install-create-run.qmd
             - docs/debug.qmd
-        - section: "User interfaces"
+        - section: "<span class='emoji-icon'>🎨</span>  __User interfaces__"
           contents:
             - docs/ui-overview.qmd
             - docs/jupyter-widgets.qmd
             - docs/ui-dynamic.qmd
             - docs/ui-html.qmd
             - docs/ui-customize.qmd
-        - section: "Reactivity"
+        - section: "<span class='emoji-icon'>⚡</span>  __Reactivity__"
           contents:
             - docs/reactive-foundations.qmd
             - docs/reactive-patterns.qmd
             - docs/reactive-mutable.qmd
-        - section: "Syntax modes"
+        - section: "<span class='emoji-icon'>📝</span>  __Syntax modes__"
           contents:
             - docs/express-vs-core.qmd
             - docs/express-or-core.qmd
             - docs/express-in-depth.qmd
             - docs/express-to-core.qmd
-        - section: "Modules"
+        - section: "<span class='emoji-icon'>📦</span>  __Modules__"
           contents:
             - docs/modules.qmd
             - docs/module-communication.qmd
-        - section: "Testing"
+        - section: "<span class='emoji-icon'>🧪</span>  __Testing__"
           contents:
             - docs/unit-testing.qmd
             - docs/end-to-end-testing.qmd
-        - section: "Extending"
+        - section: "<span class='emoji-icon'>🏗️</span>  __Extending__"
           contents:
             - docs/custom-component-one-off.qmd
             - docs/custom-components-pkg.qmd
-        - section: "Framework Comparisons"
+        - section: "<span class='emoji-icon'>📊</span>  __Comparisons__"
           contents:
             - docs/comp-streamlit.qmd
             - docs/comp-r-shiny.qmd
-        - section: "Miscellaneous"
+        - section: "<span class='emoji-icon'>🧩</span>  __Miscellaneous__"
           contents:
             - docs/nonblocking.qmd
             - docs/routing.qmd

--- a/quarto-style.scss
+++ b/quarto-style.scss
@@ -1311,6 +1311,20 @@ div.sidebar-item-container .sidebar-link > code {
   color: $gray-800;
 }
 
+.sidebar-item-section:has(.emoji-icon) {
+  .menu-text {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+  }
+
+  .sidebar-section .sidebar-item {
+    padding-left: 19px;
+  }
+}
+
+
+
 // gallery article styling
 
 .gallery p.author:before {

--- a/quarto-style.scss
+++ b/quarto-style.scss
@@ -1311,6 +1311,25 @@ div.sidebar-item-container .sidebar-link > code {
   color: $gray-800;
 }
 
+// make it even more noticable
+.sidebar-link {
+  &:hover {
+    font-weight: 500;
+  }
+
+  &.active {
+    position: relative;
+
+    &::before {
+      content: "\23F5";
+      position: absolute;
+      left: -0.9em;
+      font-size: 1em;
+      color: var(--bs-primary);
+    }
+  }
+}
+
 
 // Styling for 'Learn Shiny' (i.e., 'Concepts') sidebar, which keys
 // off the presence of emoji-icon class in the section menu title
@@ -1322,16 +1341,8 @@ div.sidebar-item-container .sidebar-link > code {
     align-items: baseline;
   }
 
-  .sidebar-link.active .menu-text {
-    color: var(--bs-primary);
-    font-weight: 500;
-  }
-
   .sidebar-section .sidebar-item {
     padding-left: 19px;
-    .menu-text:hover {
-      color: var(--bs-primary);
-    }
   }
 }
 

--- a/quarto-style.scss
+++ b/quarto-style.scss
@@ -1311,6 +1311,10 @@ div.sidebar-item-container .sidebar-link > code {
   color: $gray-800;
 }
 
+
+// Styling for 'Learn Shiny' (i.e., 'Concepts') sidebar, which keys
+// off the presence of emoji-icon class in the section menu title
+
 .sidebar-item-section:has(.emoji-icon) {
   .menu-text {
     display: flex;
@@ -1318,11 +1322,18 @@ div.sidebar-item-container .sidebar-link > code {
     align-items: baseline;
   }
 
+  .sidebar-link.active .menu-text {
+    color: var(--bs-primary);
+    font-weight: 500;
+  }
+
   .sidebar-section .sidebar-item {
     padding-left: 19px;
+    .menu-text:hover {
+      color: var(--bs-primary);
+    }
   }
 }
-
 
 
 // gallery article styling


### PR DESCRIPTION
**Before**

<img width="334" alt="Screenshot 2025-03-05 at 10 19 05 AM" src="https://github.com/user-attachments/assets/ee1e6235-caf1-41ba-9b0b-b07c5ea3cb91" />


**After**

<img width="337" alt="Screenshot 2025-03-05 at 10 18 34 AM" src="https://github.com/user-attachments/assets/4f8cd02b-779d-4b37-8d76-bafe637976f9" />
