### PR TITLE
Update to py-shinylive 0.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.8.1
+shinylive==0.8.2
 griffe


### PR DESCRIPTION
This fixes an issue with pyright in the previous version of py-shinylive.