### PR TITLE
chore: remove ?_gl* in URLs

### DIFF
--- a/docs/debug.qmd
+++ b/docs/debug.qmd
@@ -123,12 +123,12 @@ Note also that Shiny applications use Python's asyncio under the hood, so it may
 
 ### shinyapps.io
 
-  1. For documentation and instructions on how to use [shinyapps.io](http://shinyapps.io){target="_blank"}, see the [shinyapps.io user guide](https://docs.posit.co/shinyapps.io/?_gl=1*fwm1mn*_ga*MjQzNjU5NDUuMTY0ODgyOTc5Ng..*_ga_HXP006LBGY*MTY5MTQ0NjYwNy41LjAuMTY5MTQ0NjYwOS4wLjAuMA..){target="_blank"}.
+  1. For documentation and instructions on how to use [shinyapps.io](http://shinyapps.io){target="_blank"}, see the [shinyapps.io user guide](https://docs.posit.co/shinyapps.io/){target="_blank"}.
 
-  2. The best place to get community support for shinyapps.io is the [shinyapps.io category on Posit Community](https://community.rstudio.com/tags/shinyappsio?_gl=1*nqeupu*_ga*MjQzNjU5NDUuMTY0ODgyOTc5Ng..*_ga_2C0WZ1JHG0*MTY5MTQ0NjYwNy41LjAuMTY5MTQ0NjYwOS4wLjAuMA..*_ga_HXP006LBGY*MTY5MTQ0NjYwNy41LjAuMTY5MTQ0NjYwOS4wLjAuMA..){target="_blank"}. If you're having difficulties with shinyapps.io, feel free to ask questions there. Another option is to file an issue in the [rsconnect-python package repo](https://github.com/rstudio/rsconnect-python/issues){target="_blank"}.
+  2. The best place to get community support for shinyapps.io is the [shinyapps.io category on Posit Community](https://community.rstudio.com/tags/shinyappsio){target="_blank"}. If you're having difficulties with shinyapps.io, feel free to ask questions there. Another option is to file an issue in the [rsconnect-python package repo](https://github.com/rstudio/rsconnect-python/issues){target="_blank"}.
 
 
-  3. Customers with Starter, Basic, Standard or Pro subscriptions can get direct access to our support engineers by opening a case on [the Posit Support site](https://support.posit.co/?_gl=1*1aff1iz*_ga*MjQzNjU5NDUuMTY0ODgyOTc5Ng..*_ga_2C0WZ1JHG0*MTY5MTQ0NjYwNy41LjAuMTY5MTQ0NjYwOS4wLjAuMA..*_ga_HXP006LBGY*MTY5MTQ0NjYwNy41LjAuMTY5MTQ0NjYwOS4wLjAuMA..){target="_blank"}. Questions are answered from 9AM - 5PM(EST) Monday - Friday.
+  3. Customers with Starter, Basic, Standard or Pro subscriptions can get direct access to our support engineers by opening a case on [the Posit Support site](https://support.posit.co/){target="_blank"}. Questions are answered from 9AM - 5PM(EST) Monday - Friday.
 
 
 ### Posit Connect and Shiny Server Pro

--- a/gallery/gallery.yml
+++ b/gallery/gallery.yml
@@ -63,7 +63,7 @@
       thumbnail: t_test.png
     - title: AWS Community Builders Dashboard
       description: null
-      href: https://gallery.shinyapps.io/aws-community-builders-dashboard/?_gl=1*1skp1jv*_ga*MjAwNjU0MTEzMS4xNzI4NDEzMzYw*_ga_2C0WZ1JHG0*MTcyODQxOTEwMC42LjEuMTcyODQxOTExMC4wLjAuMA..
+      href: https://gallery.shinyapps.io/aws-community-builders-dashboard/
       code: https://github.com/robertgv/aws-community-builders-dashboard
       thumbnail: aws-builders.jpg
     - title: Identify Outliers


### PR DESCRIPTION
Removing the `?_gl*` parts to links.