### PR TITLE
fix: Hero text

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -18,12 +18,12 @@ repo-actions: false
 :::{.grid}
 :::{.g-col-12 .g-col-xl-6 .hero-text .pt-5 .pt-md-4 .px-3 .px-md-5 .pe-xl-0}
 
-<div class="gradient-text display-4 fw-bolder", style="font-size:4.7rem;">
+<div class="gradient-text display-1 fw-bolder" style="letter-spacing: -3px;">
 Reactive data & AI&nbsp;apps in pure Python
 </div>
 
 <p class="h4">
-elegant, efficient, and ready for production
+Elegant, efficient, and ready for production
 </p>
 
 ::: {.pt-4 .pb-4 style="z-index:1;"}

--- a/quarto-style.scss
+++ b/quarto-style.scss
@@ -1122,9 +1122,6 @@ div.gradient-text {
     #202020
   );
   background-size: 800%;
-  font-weight: 900;
-  font-size: 4.1rem;
-  letter-spacing: -3px;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: animated_text 30s ease-in-out infinite;
@@ -1132,22 +1129,7 @@ div.gradient-text {
   -webkit-animation: animated_text 30s ease-in-out infinite;
 }
 
-@media only screen and (min-width: 1200px) {
-  div.gradient-text {
-    font-size: 5rem;
-  }
-}
-
-@media only screen and (max-width: 1199px) {
-  div.gradient-text {
-    font-size: 4.2rem;
-  }
-}
-
 @media only screen and (max-width:767px) {
-  div.gradient-text {
-    font-size: 2.75rem;
-  }
   .hero-text .h4 {
     font-size: 1.25em;
   }


### PR DESCRIPTION
Updates the hero text on the front page to use Bootstraps `.display-1` for `font-size` and `line-height`, resulting in better display at all screen sizes.

This also untangles the `.gradient-text` class from font size and weight considerations.

## Before

![image](https://github.com/user-attachments/assets/707a1ed1-a106-4151-b51b-a07b4a66512a)


## After 

![image](https://github.com/user-attachments/assets/935cd502-e51e-469d-abab-882012532f5e)
