### PR TITLE
bug(images): use relative links to reference gallery images, breaking prod site

### DIFF
--- a/get-started/gallery-highlight.yml
+++ b/get-started/gallery-highlight.yml
@@ -1,29 +1,29 @@
 - title: Superzip explorer
   href: https://gallery.shinyapps.io/superzip/
   code: https://github.com/posit-dev/py-shinywidgets/tree/main/examples/superzip/
-  thumbnail: /gallery/superzip.png
+  thumbnail: ../gallery/superzip.png
 
 - title: Restaurant tips dashboard
   href: https://gallery.shinyapps.io/template-dashboard-tips1/
   code: ../templates/dashboard-tips/
-  thumbnail: /gallery/restaurant-tips.png
+  thumbnail: ../gallery/restaurant-tips.png
 
 - title: Stock prices
   href: https://gallery.shinyapps.io/template-stock-app/
   code: ../templates/stock-app/
-  thumbnail: /gallery/stock-prices.png
+  thumbnail: ../gallery/stock-prices.png
 
 - title: Respiratory Disease data
   href: https://gallery.shinyapps.io/respiratory_disease_pyshiny/
   code: https://github.com/rstudio/shiny-gallery/tree/master/respiratory_disease_pyshiny
-  thumbnail: /gallery/respiratory-disease.png
+  thumbnail: ../gallery/respiratory-disease.png
 
 - title: AWS Community Builders Dashboard
   href: https://gallery.shinyapps.io/aws-community-builders-dashboard/?_gl=1*1skp1jv*_ga*MjAwNjU0MTEzMS4xNzI4NDEzMzYw*_ga_2C0WZ1JHG0*MTcyODQxOTEwMC42LjEuMTcyODQxOTExMC4wLjAuMA..
   code: https://github.com/robertgv/aws-community-builders-dashboard
-  thumbnail: /gallery/aws-builders.jpg
+  thumbnail: ../gallery/aws-builders.jpg
 
 - title: Identify Outliers
   href: https://connect.posit.cloud/skaltman/content/01922aab-06e0-fc8f-8958-30dd67f9af51
   code: https://github.com/skaltman/outliers-app-db-python
-  thumbnail: /gallery/identify-outliers.jpg
+  thumbnail: ../gallery/identify-outliers.jpg

--- a/get-started/gallery-highlight.yml
+++ b/get-started/gallery-highlight.yml
@@ -19,7 +19,7 @@
   thumbnail: ../gallery/respiratory-disease.png
 
 - title: AWS Community Builders Dashboard
-  href: https://gallery.shinyapps.io/aws-community-builders-dashboard/?_gl=1*1skp1jv*_ga*MjAwNjU0MTEzMS4xNzI4NDEzMzYw*_ga_2C0WZ1JHG0*MTcyODQxOTEwMC42LjEuMTcyODQxOTExMC4wLjAuMA..
+  href: https://gallery.shinyapps.io/aws-community-builders-dashboard/
   code: https://github.com/robertgv/aws-community-builders-dashboard
   thumbnail: ../gallery/aws-builders.jpg
 


### PR DESCRIPTION
images in the production site for the gallery and templates are 404-ing

![image](https://github.com/user-attachments/assets/cd9b4247-1606-4aca-af09-2a6f141f78a3)


working locally with the reference to use `../gallery` instead of `/gallery`

![image](https://github.com/user-attachments/assets/5366ea8a-83c7-46b0-8148-1d176957673e)
