### PR TITLE
Don't show a flash of shinylive source code

### DIFF
--- a/components/_partials/components.css
+++ b/components/_partials/components.css
@@ -80,3 +80,7 @@ main a.nav-link:hover {
   height: calc(1 / var(--scale-factor) * 100%);
   transform-origin: top left;
 }
+
+.shinylive-python code {
+  visibility: hidden;
+}

--- a/components/_partials/components.css
+++ b/components/_partials/components.css
@@ -81,7 +81,7 @@ main a.nav-link:hover {
   transform-origin: top left;
 }
 
-.shinylive-wrapper code {
+.shinylive-python code {
   visibility: hidden;
   height: 200px;
 }

--- a/components/_partials/components.css
+++ b/components/_partials/components.css
@@ -83,4 +83,5 @@ main a.nav-link:hover {
 
 .shinylive-python code {
   visibility: hidden;
+  height: 200px;
 }

--- a/components/_partials/components.css
+++ b/components/_partials/components.css
@@ -81,7 +81,7 @@ main a.nav-link:hover {
   transform-origin: top left;
 }
 
-.shinylive-python code {
+.shinylive-wrapper code {
   visibility: hidden;
   height: 200px;
 }

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -85,7 +85,7 @@ Create efficient, reactive, and robust web applications and dashboards.
   border-left: none;
 }
 
-.shinylive-wrapper code {
+.shinylive-python code {
   visibility: hidden;
   height: 400px;
 }

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -42,7 +42,7 @@ Create efficient, reactive, and robust web applications and dashboards.
   <div class="traffic-light green"></div>
 </div>
 ```
-<pre><code class="language-python" style="visibility: hidden">
+<pre><code class="language-python" style="visibility: hidden; height: 400px;">
 {{< include assets/code-welcome.py >}}
 </code></pre>
 <script>(function() {

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -42,7 +42,7 @@ Create efficient, reactive, and robust web applications and dashboards.
   <div class="traffic-light green"></div>
 </div>
 ```
-<pre><code class="language-python" style="visibility: hidden; height: 400px;">
+<pre><code class="language-python">
 {{< include assets/code-welcome.py >}}
 </code></pre>
 <script>(function() {
@@ -83,6 +83,11 @@ Create efficient, reactive, and robust web applications and dashboards.
   border-right: none;
   border-bottom: none;
   border-left: none;
+}
+
+.shinylive-wrapper code {
+  visibility: hidden;
+  height: 400px;
 }
 
 .floating-code-app {

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -84,6 +84,10 @@ Create efficient, reactive, and robust web applications and dashboards.
   border-left: none;
 }
 
+.floating-app .shinylive-wrapper code {
+  visibility: hidden;
+}
+
 .floating-code-app {
   position: relative;
   width: 100%;

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -42,9 +42,10 @@ Create efficient, reactive, and robust web applications and dashboards.
   <div class="traffic-light green"></div>
 </div>
 ```
-<pre><code class="language-python">
+<pre><code class="language-python" style="visibility: hidden">
 {{< include assets/code-welcome.py >}}
-</code></pre><script>(function() {
+</code></pre>
+<script>(function() {
   // Trim leading/trailing newlines from the code-welcome code block
   const preElement = document.currentScript.previousElementSibling;
   if (!preElement || preElement.tagName !== 'PRE') return;
@@ -82,10 +83,6 @@ Create efficient, reactive, and robust web applications and dashboards.
   border-right: none;
   border-bottom: none;
   border-left: none;
-}
-
-.floating-app .shinylive-wrapper code {
-  visibility: hidden;
 }
 
 .floating-code-app {

--- a/get-started/what-is-shiny.qmd
+++ b/get-started/what-is-shiny.qmd
@@ -38,10 +38,6 @@ repo-actions: false
     text-decoration: none;
     border: 1px solid var(--bs-primary);
   }
-
-  .shinylive-python > code {
-    visibility: hidden;
-  }
 </style>
 ```
 

--- a/get-started/what-is-shiny.qmd
+++ b/get-started/what-is-shiny.qmd
@@ -38,6 +38,10 @@ repo-actions: false
     text-decoration: none;
     border: 1px solid var(--bs-primary);
   }
+
+  .shinylive-python > code {
+    visibility: hidden;
+  }
 </style>
 ```
 


### PR DESCRIPTION
Perhaps we should do this more generally too since the components pages suffer from the same problem.

And also seems like shinylive should be doing this automatically?