### PR TITLE
chore(URLs): fix link changes from #291

### DIFF
--- a/docs/comp-r-shiny.qmd
+++ b/docs/comp-r-shiny.qmd
@@ -24,7 +24,7 @@ Shiny [express](express-vs-core.qmd) is a new, more expressive, way to build PyS
 # Getting started
 
 R users tend to use the R console to install and run Shiny while Python requires you to use the terminal.
-To get started you can do the following (or see the [installation instructions](install-create-run.qmd) for a more in-depth explanation):
+To get started you can do the following (or see the [installation instructions](/get-started/install.qmd) for a more in-depth explanation):
 
 1.  In your terminal, create a new directory with `mkdir <my_directory>` and navigate into it with `cd <my_directory>`
 2.  Install Shiny. We strongly recommend using a virtual environment for this as it will eliminate dependency resolution headaches and make deployment easier.

--- a/docs/jupyter-widgets.qmd
+++ b/docs/jupyter-widgets.qmd
@@ -535,9 +535,9 @@ For more layout inspiration, check out the [Layout Gallery](/layouts).
 
 ## Shinylive
 
-Examples on this page are powered by [shinylive](shinylive.qmd), a tool for running Shiny apps in the browser (via [pyodide](https://pyodide.org/en/stable/)).
+Examples on this page are powered by [shinylive](/get-started/shinylive.qmd), a tool for running Shiny apps in the browser (via [pyodide](https://pyodide.org/en/stable/)).
 Generally speaking, apps that use shinywidgets should work in shinylive as long as the widget and app code is supported by pyodide.
-The shinywidgets package itself comes pre-installed in shinylive, but you'll need to include any other dependencies [in the `requirements.txt` file](shinylive.qmd#requiring-extra-packages-with-requirements.txt).
+The shinywidgets package itself comes pre-installed in shinylive, but you'll need to include any other dependencies [in the `requirements.txt` file](/get-started/shinylive.qmd#requiring-extra-packages-with-requirements.txt).
 
 
 ## Examples

--- a/docs/overview.qmd
+++ b/docs/overview.qmd
@@ -20,7 +20,7 @@ In the [next article](user-interfaces.qmd), we'll cover more user interface (UI)
 ::: {.callout-tip}
 ## Editable examples
 
-Many examples on this site have a code editor for modifying the source code for a Shiny app (which runs entirely in the browser, thanks to [shinylive](shinylive.qmd)).
+Many examples on this site have a code editor for modifying the source code for a Shiny app (which runs entirely in the browser, thanks to [shinylive](/get-started/shinylive.qmd)).
 If you'd like to run any examples locally, first [install and run](install-create-run.qmd) Shiny locally, then copy/paste relevant code into the `app.py` file (created by `shiny create`).
 :::
 
@@ -520,7 +520,7 @@ For a more in-depth look at reactivity, check out the [reactivity article](react
 
 ### Starter templates {#templates}
 
-Once you've [installed](install-create-run.qmd) Shiny, the `shiny create` CLI command provides access to a collection of useful starter templates. This command walks you through a series of prompts to help you get started quickly with a helpful example. One great option is the dashboard template, which can be created with:
+Once you've [installed](/get-started/install.qmd) Shiny, the `shiny create` CLI command provides access to a collection of useful starter templates. This command walks you through a series of prompts to help you get started quickly with a helpful example. One great option is the dashboard template, which can be created with:
 
 ```bash
 shiny create --template dashboard

--- a/docs/overview.qmd
+++ b/docs/overview.qmd
@@ -21,7 +21,7 @@ In the [next article](user-interfaces.qmd), we'll cover more user interface (UI)
 ## Editable examples
 
 Many examples on this site have a code editor for modifying the source code for a Shiny app (which runs entirely in the browser, thanks to [shinylive](/get-started/shinylive.qmd)).
-If you'd like to run any examples locally, first [install and run](install-create-run.qmd) Shiny locally, then copy/paste relevant code into the `app.py` file (created by `shiny create`).
+If you'd like to run any examples locally, first [install](/get-started/install.qmd) Shiny locally, then [create and run](/get-started/create-run.qmd) by copy/paste relevant code into the `app.py` file (created by `shiny create`).
 :::
 
 
@@ -531,7 +531,7 @@ shiny create --template dashboard
 ::: {.callout-tip}
 ## Development workflow
 
-See the [workflow](install-create-run.qmd) section for more information developing Shiny apps locally.
+See how to [create and run apps](/get-started/create-run.qmd) for more information developing Shiny apps locally.
 Also keep in mind you can develop apps in the browser using the [playground](https://shinylive.io/py/examples/).
 :::
 

--- a/docs/routing.qmd
+++ b/docs/routing.qmd
@@ -36,5 +36,4 @@ routes = [
 app = Starlette(routes=routes)
 ```
 
-This application can be run using tools like `uvicorn`, as discussed in [deployment](deploy-on-prem.qmd).
-
+This application can be run using tools like `uvicorn`, as discussed in [deployment](/get-started/deploy-on-prem.qmd).

--- a/docs/user-interfaces.qmd
+++ b/docs/user-interfaces.qmd
@@ -395,7 +395,7 @@ ridgeplot==0.1.25
 
 ## Next steps
 
-If you'd like to start developing Shiny apps locally, see the next section on [workflow](install-create-run.qmd).
+If you'd like to start developing Shiny apps locally, see the get started section on [creating and running apps](/get-started/create-run.qmd).
 
 Otherwise, to keep learning more about some of the topics covered here, see the following:
 

--- a/get-started/create-run.qmd
+++ b/get-started/create-run.qmd
@@ -2,7 +2,7 @@
 title: "Create and Run"
 ---
 
-When you [install shiny](get-started/install.qmd), you also install the `shiny` command line interface (CLI).
+When you [install shiny](install.qmd), you also install the `shiny` command line interface (CLI).
 You can use this interface to help you create and run your Shiny applications.
 
 ## Create a Shiny application

--- a/get-started/include/why-virtual-env.qmd
+++ b/get-started/include/why-virtual-env.qmd
@@ -3,5 +3,5 @@ When building Shiny applications, especially in a production environment, it is 
 Why use a virtual environment?
 
 - Keeps your application's dependencies isolated from other global Python packages.
-- Makes your application easier to [deploy and share](deploy.qmd).
+- Makes your application easier to [deploy and share](/get-started/deploy.qmd).
 - Helps avoid version conflicts between different projects.

--- a/templates/stock-app/index.qmd
+++ b/templates/stock-app/index.qmd
@@ -32,7 +32,7 @@ Note that the icon for the stock price change is a green arrow pointing up if th
 **Components:**
 
 * [Select input](/components/inputs/selectize-single/index.qmd)
-* [Date range input](/components/inputs/date-range/index.qmd)
+* [Date range input](/components/inputs/date-range-selector/index.qmd)
 * [Value box](/components/outputs/value-box/index.qmd)
 * [Plotly](/components/outputs/plot-plotly/index.qmd)
 * [Data grid output](/components/outputs/data-grid/index.qmd)


### PR DESCRIPTION
fixes the links mentioned in #291 and #290.

~~The `get-started/include/deploy.qmd` issue seems to be okay? since it's mainly used as an include so the reference directory is the /get-started/install.qmd directory~~