### PR TITLE
Fix broken gallery app link

### DIFF
--- a/gallery/gallery.yml
+++ b/gallery/gallery.yml
@@ -68,7 +68,7 @@
       thumbnail: aws-builders.jpg
     - title: Identify Outliers
       description: null
-      href: https://connect.posit.cloud/skaltman/content/01922aab-06e0-fc8f-8958-30dd67f9af51
+      href: https://skaltman-outliers-app-db-python.share.connect.posit.cloud/
       code: https://github.com/skaltman/outliers-app-db-python
       thumbnail: identify-outliers.jpg
     # - title: Shinywidgets output examples

--- a/get-started/gallery-highlight.yml
+++ b/get-started/gallery-highlight.yml
@@ -24,6 +24,6 @@
   thumbnail: ../gallery/aws-builders.jpg
 
 - title: Identify Outliers
-  href: https://connect.posit.cloud/skaltman/content/01922aab-06e0-fc8f-8958-30dd67f9af51
+  href: https://skaltman-outliers-app-db-python.share.connect.posit.cloud/
   code: https://github.com/skaltman/outliers-app-db-python
   thumbnail: ../gallery/identify-outliers.jpg


### PR DESCRIPTION
The link to the "Identify outliers" app is broken. Not sure what happened, but I updated `gallery.yml` and `gallery-highlight.yml` to use a working link.