### PR TITLE
Feat: Add plausible tracking

### DIFF
--- a/_plausible.html
+++ b/_plausible.html
@@ -1,6 +1,0 @@
-<!-- Privacy-friendly analytics by Plausible -->
-<script async src="https://plausible.io/js/pa-evGN_AU3I78BASS5GjxP0.js"></script>
-<script>
-  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-  plausible.init()
-</script>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -323,7 +323,6 @@ format:
     include-before-body: include-before-body.html
     include-in-header:
       - "include-in-header.html"
-      - "_plausible.html"
       - text: |
           <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js"
             data-light-bg="#0073b5"

--- a/include-in-header.html
+++ b/include-in-header.html
@@ -28,6 +28,14 @@
 </script>
 <!-- End Add rel="noopener noreferrer" to each target="_blank" -->
 
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-evGN_AU3I78BASS5GjxP0.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>
+<!-- End Privacy-friendly analytics by Plausible -->
+
 <script type="text/javascript">
   (function () {
     function addShinyliveEditLinks() {


### PR DESCRIPTION
Add the Plausible analytics code as given by DevRel to the head tag.

Note, when Quarto 1.9 is released, we can switch to using the built-in Plausible support (see https://quarto.org/docs/download/prerelease.html and https://github.com/quarto-dev/quarto-cli/pull/13524) for details.