### PR TITLE
Add popovers component documentation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -172,6 +172,7 @@ website:
             - components/display-messages/chat/index.qmd
             - components/display-messages/modal/index.qmd
             - components/display-messages/notifications/index.qmd
+            - components/display-messages/popovers/index.qmd
             - components/display-messages/progress-bar/index.qmd
             - components/display-messages/tooltips/index.qmd
 

--- a/components/display-messages/popovers/app-core.py
+++ b/components/display-messages/popovers/app-core.py
@@ -1,0 +1,14 @@
+from shiny import ui, App
+
+app_ui = ui.page_fluid(
+    ui.popover( # <<
+        ui.input_action_button("btn", "Click me"),
+        "This is a popover with helpful information!",
+        title="Popover Title",
+    ),
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)

--- a/components/display-messages/popovers/app-detail-preview.py
+++ b/components/display-messages/popovers/app-detail-preview.py
@@ -1,0 +1,26 @@
+from shiny import ui, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Popover Examples"),
+    ui.popover(
+        ui.input_action_button("btn1", "Click me"),
+        ui.div(
+            ui.strong("Popover Title"),
+            ui.p("This popover contains rich content including formatted text and multiple paragraphs."),
+            ui.p("Click outside to dismiss."),
+        ),
+        placement="right",
+    ),
+    ui.br(), ui.br(),
+    ui.popover(
+        ui.span("Hover over this text", class_="text-primary", style="cursor: help;"),
+        "Quick info appears on hover",
+        placement="top",
+        options={"trigger": "hover focus"},
+    ),
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)

--- a/components/display-messages/popovers/app-express.py
+++ b/components/display-messages/popovers/app-express.py
@@ -1,0 +1,5 @@
+from shiny.express import ui
+
+with ui.popover(title="Popover Title"): # <<
+    ui.input_action_button("btn", "Click me")
+    "This is a popover with helpful information!"

--- a/components/display-messages/popovers/app-preview.py
+++ b/components/display-messages/popovers/app-preview.py
@@ -1,0 +1,17 @@
+from shiny import ui, App
+
+app_ui = ui.page_fluid(
+    ui.popover(
+        ui.span("Hover over this text", class_="text-primary", style="cursor: help;"),
+        "Popover content appears here",
+        title="Info",
+        placement="top",
+        options={"trigger": "hover focus"},
+    ),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)

--- a/components/display-messages/popovers/index.qmd
+++ b/components/display-messages/popovers/index.qmd
@@ -1,0 +1,71 @@
+---
+title: Popovers
+sidebar: components
+appPreview:
+  file: components/display-messages/popovers/app-preview.py
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/display-messages/popovers/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 250
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkDOFGIVOANzgAdCI2ZsuPLHAAe6Ma1Z8BQkQF0gA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAQUxEGcKMQqcAbnCIBXTgB0IGirnRxWyALzJgcsABM4dKPoA2FVRTPw5AS2TAAFKuQBeAHwBdIA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.popover
+    href: https://shiny.posit.co/py/api/ui.popover.html
+    signature: ui.popover(trigger, *args, title=None, id=None, placement='auto', options=None, **kwargs)
+  - title: ui.update_popover
+    href: https://shiny.posit.co/py/api/ui.update_popover.html
+    signature: ui.update_popover(id, *args, title=None, show=None, session=None)
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A popover displays rich content in a small overlay when a user clicks or hovers over a trigger element. Unlike tooltips which show only plain text on hover, popovers can contain formatted content, images, buttons, and other UI elements.
+
+To add a popover to your app:
+
+1. Wrap a trigger element (like a button or text) with `ui.popover()`.
+
+2. Pass the content to display as additional arguments. This can be text, formatted HTML, or any UI elements.
+
+3. Optionally specify a `title` to show a header, and `placement` to control where the popover appears relative to the trigger.
+
+**Trigger Element**: The first argument is the element that triggers the popover. This can be:
+  - A button (`ui.input_action_button()`)
+  - Text or icons (`ui.span()`, `ui.tags.i()`)
+  - Any other UI element
+
+**Content**: Additional arguments become the popover content. You can include:
+  - Plain text strings
+  - Formatted HTML with `ui.div()`, `ui.p()`, `ui.strong()`, etc.
+  - Links, images, or even interactive elements
+
+**Placement**: Control where the popover appears with the `placement` parameter:
+  - `"auto"` (default) - Automatically choose the best position
+  - `"top"`, `"bottom"`, `"left"`, `"right"` - Fixed positions
+
+**Show/Hide Behavior**:
+  - Click the trigger to show/hide the popover
+  - Click outside the popover to dismiss it
+  - Popovers close automatically when clicking elsewhere
+
+**Programmatic Control**: Use `ui.update_popover()` to show, hide, or update popover content from the server.
+
+See Also: [Tooltips](../tooltips/index.qmd) provide simpler hover-based help text without rich content.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe>=1.3.2,<2.0.0
+griffe

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe
+griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary
- Adds documentation for the `ui.popover()` component
- Includes Express and Core examples with interactive previews
- Adds navigation entry to components sidebar

## Test plan
- [ ] Preview site renders correctly
- [ ] Popover examples work in Shinylive
- [ ] Navigation links to new component page

🤖 Generated with [Claude Code](https://claude.com/claude-code)