### PR TITLE
Add toasts component documentation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -173,6 +173,7 @@ website:
             - components/display-messages/modal/index.qmd
             - components/display-messages/notifications/index.qmd
             - components/display-messages/progress-bar/index.qmd
+            - components/display-messages/toasts/index.qmd
             - components/display-messages/tooltips/index.qmd
 
     - id: layouts

--- a/components/display-messages/toasts/app-core.py
+++ b/components/display-messages/toasts/app-core.py
@@ -1,0 +1,13 @@
+from shiny import ui, reactive, App
+
+app_ui = ui.page_fluid(
+    ui.input_action_button("show", "Show toast"),
+)
+
+def server(input, output, session):
+    @reactive.effect
+    @reactive.event(input.show)
+    def _():
+        ui.show_toast("Hello! This is a toast message.") # <<
+
+app = App(app_ui, server)

--- a/components/display-messages/toasts/app-detail-preview.py
+++ b/components/display-messages/toasts/app-detail-preview.py
@@ -1,0 +1,30 @@
+from shiny import ui, reactive, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Toast Examples"),
+    ui.input_action_button("show_toast", "Show Toast"),
+    ui.input_action_button("show_success", "Show Success"),
+    ui.input_action_button("show_warning", "Show Warning"),
+)
+
+def server(input, output, session):
+    @reactive.effect
+    @reactive.event(input.show_toast)
+    def _():
+        ui.show_toast("This is a default toast message.")
+
+    @reactive.effect
+    @reactive.event(input.show_success)
+    def _():
+        ui.show_toast(
+            ui.toast("Operation completed successfully!", type="success")
+        )
+
+    @reactive.effect
+    @reactive.event(input.show_warning)
+    def _():
+        ui.show_toast(
+            ui.toast("Please review this warning.", type="warning")
+        )
+
+app = App(app_ui, server)

--- a/components/display-messages/toasts/app-express.py
+++ b/components/display-messages/toasts/app-express.py
@@ -1,0 +1,9 @@
+from shiny import reactive
+from shiny.express import input, ui
+
+ui.input_action_button("show", "Show toast")
+
+@reactive.effect
+@reactive.event(input.show)
+def _():
+    ui.show_toast("Hello! This is a toast message.") # <<

--- a/components/display-messages/toasts/app-preview.py
+++ b/components/display-messages/toasts/app-preview.py
@@ -1,0 +1,21 @@
+## file: app.py
+from shiny import ui, reactive, App
+from pathlib import Path
+
+appdir = Path(__file__).parent
+app_ui = ui.page_fillable(
+    ui.include_css(appdir / "styles.css"),
+    ui.input_action_button("show", "Show Toast"),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+def server(input, output, session):
+    @reactive.effect
+    @reactive.event(input.show)
+    def _():
+        ui.show_toast("This is a toast notification!")
+
+app = App(app_ui, server)
+
+## file: styles.css
+# shiny-notification-panel { max-width: 100%; }

--- a/components/display-messages/toasts/app-variation-positions-express.py
+++ b/components/display-messages/toasts/app-variation-positions-express.py
@@ -1,0 +1,34 @@
+from shiny import reactive
+from shiny.express import input, ui
+
+ui.h4("Toast Positions")
+ui.input_action_button("top_left", "Top Left")
+ui.input_action_button("top_center", "Top Center")
+ui.input_action_button("top_right", "Top Right")
+ui.input_action_button("bottom_left", "Bottom Left")
+ui.input_action_button("bottom_right", "Bottom Right")
+
+@reactive.effect
+@reactive.event(input.top_left)
+def _():
+    ui.show_toast(ui.toast("Top left position", position="top-left"))
+
+@reactive.effect
+@reactive.event(input.top_center)
+def _():
+    ui.show_toast(ui.toast("Top center position", position="top-center"))
+
+@reactive.effect
+@reactive.event(input.top_right)
+def _():
+    ui.show_toast(ui.toast("Top right position", position="top-right"))
+
+@reactive.effect
+@reactive.event(input.bottom_left)
+def _():
+    ui.show_toast(ui.toast("Bottom left position", position="bottom-left"))
+
+@reactive.effect
+@reactive.event(input.bottom_right)
+def _():
+    ui.show_toast(ui.toast("Bottom right position", position="bottom-right"))

--- a/components/display-messages/toasts/app-variation-positions.py
+++ b/components/display-messages/toasts/app-variation-positions.py
@@ -1,0 +1,38 @@
+from shiny import ui, reactive, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Toast Positions"),
+    ui.input_action_button("top_left", "Top Left"),
+    ui.input_action_button("top_center", "Top Center"),
+    ui.input_action_button("top_right", "Top Right"),
+    ui.input_action_button("bottom_left", "Bottom Left"),
+    ui.input_action_button("bottom_right", "Bottom Right"),
+)
+
+def server(input, output, session):
+    @reactive.effect
+    @reactive.event(input.top_left)
+    def _():
+        ui.show_toast(ui.toast("Top left position", position="top-left"))
+
+    @reactive.effect
+    @reactive.event(input.top_center)
+    def _():
+        ui.show_toast(ui.toast("Top center position", position="top-center"))
+
+    @reactive.effect
+    @reactive.event(input.top_right)
+    def _():
+        ui.show_toast(ui.toast("Top right position", position="top-right"))
+
+    @reactive.effect
+    @reactive.event(input.bottom_left)
+    def _():
+        ui.show_toast(ui.toast("Bottom left position", position="bottom-left"))
+
+    @reactive.effect
+    @reactive.event(input.bottom_right)
+    def _():
+        ui.show_toast(ui.toast("Bottom right position", position="bottom-right"))
+
+app = App(app_ui, server)

--- a/components/display-messages/toasts/app-variation-types-express.py
+++ b/components/display-messages/toasts/app-variation-types-express.py
@@ -1,0 +1,28 @@
+from shiny import reactive
+from shiny.express import input, ui
+
+ui.h4("Toast Types")
+ui.input_action_button("success", "Success")
+ui.input_action_button("info", "Info")
+ui.input_action_button("warning", "Warning")
+ui.input_action_button("danger", "Danger")
+
+@reactive.effect
+@reactive.event(input.success)
+def _():
+    ui.show_toast(ui.toast("Operation successful!", type="success"))
+
+@reactive.effect
+@reactive.event(input.info)
+def _():
+    ui.show_toast(ui.toast("Here's some information", type="info"))
+
+@reactive.effect
+@reactive.event(input.warning)
+def _():
+    ui.show_toast(ui.toast("Warning: Check your input", type="warning"))
+
+@reactive.effect
+@reactive.event(input.danger)
+def _():
+    ui.show_toast(ui.toast("Error: Operation failed", type="danger"))

--- a/components/display-messages/toasts/app-variation-types.py
+++ b/components/display-messages/toasts/app-variation-types.py
@@ -1,0 +1,32 @@
+from shiny import ui, reactive, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Toast Types"),
+    ui.input_action_button("success", "Success"),
+    ui.input_action_button("info", "Info"),
+    ui.input_action_button("warning", "Warning"),
+    ui.input_action_button("danger", "Danger"),
+)
+
+def server(input, output, session):
+    @reactive.effect
+    @reactive.event(input.success)
+    def _():
+        ui.show_toast(ui.toast("Operation successful!", type="success"))
+
+    @reactive.effect
+    @reactive.event(input.info)
+    def _():
+        ui.show_toast(ui.toast("Here's some information", type="info"))
+
+    @reactive.effect
+    @reactive.event(input.warning)
+    def _():
+        ui.show_toast(ui.toast("Warning: Check your input", type="warning"))
+
+    @reactive.effect
+    @reactive.event(input.danger)
+    def _():
+        ui.show_toast(ui.toast("Error: Operation failed", type="danger"))
+
+app = App(app_ui, server)

--- a/components/display-messages/toasts/index.qmd
+++ b/components/display-messages/toasts/index.qmd
@@ -1,0 +1,113 @@
+---
+title: Toasts
+sidebar: components
+appPreview:
+  file: components/display-messages/toasts/app-preview.py
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/display-messages/toasts/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 200
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhXER0AVwpEFnADoQNqrN0UUA+lGIVO5fQCMlFcgAo1YDqQDu9ovYDK7Z8mtRWFewBKDQ0AAW04Ojo4YzCIgDdqChtdJSxHJ2CIABNI5H0bQMQNZFLkbQz9X387MAAJOAAbRtIAQmQAFS4xTjEoH1I-WXhRKABzOCwg5ABiZAAeeY1CVApcdAQUMCp+CjAAXwBdIA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAV05EGcKMQqcAbnCIBBTAB0IGjOgD645AF4xnHFADmcHXQA24gCYAKDchfGs3dKIo6Zc8joAjLwpyJzAOUgB3NUJkGIBldijkEKhWChiASgINTI0NOzg6NjgGRQYHDy8iUi9PCiJWOFZWTnJMxGdXAAEpXwU4LCK6OFkul17pWQGhxUpKiHqsCMi8iFdkQuKdBw7xjbcVnVT0sIAJOGtrUgBCZAAVLlY+Z6gU0jSReBbzQazkADEyAAPMD8tBMIZkKp0A5tHoJCUyqU1rEwBRcOgECh0XAAB4UMAAXwAukA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.toast
+    href: https://shiny.posit.co/py/api/ui.toast.html
+    signature: ui.toast(*args, header=None, icon=None, id=None, type=None, duration_s=5,
+      position='top-right', closable=True, **kwargs)
+  - title: ui.toast_header
+    href: https://shiny.posit.co/py/api/ui.toast_header.html
+    signature: ui.toast_header(title, *args, icon=None, status=None, **kwargs)
+  - title: ui.show_toast
+    href: https://shiny.posit.co/py/api/ui.show_toast.html
+    signature: ui.show_toast(toast, *, session=None)
+  - title: ui.hide_toast
+    href: https://shiny.posit.co/py/api/ui.hide_toast.html
+    signature: ui.hide_toast(id, *, session=None)
+- id: variations
+  template: ../../_partials/components-variations.ejs
+  template-params:
+    dir: components/display-messages/toasts/
+  contents:
+  - title: Toast positions
+    description: 'Toasts can appear in 9 different screen positions: `"top-left"`,
+      `"top-center"`, `"top-right"`, `"middle-left"`, `"middle-center"`, `"middle-right"`,
+      `"bottom-left"`, `"bottom-center"`, and `"bottom-right"`. The default is `"top-right"`.
+
+      '
+    apps:
+    - title: Preview
+      file: app-variation-positions.py
+      height: 250
+    - title: Express
+      file: app-variation-positions-express.py
+    - title: Core
+      file: app-variation-positions.py
+  - title: Toast types
+    description: 'Toasts support different types for color-coding messages: `"primary"`,
+      `"secondary"`, `"success"`, `"info"`, `"warning"`, `"danger"` (or `"error"`),
+      `"light"`, and `"dark"`. Use these to indicate the nature of the message.
+
+      '
+    apps:
+    - title: Preview
+      file: app-variation-types.py
+      height: 220
+    - title: Express
+      file: app-variation-types-express.py
+    - title: Core
+      file: app-variation-types.py
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+Toasts are temporary notification messages that appear on screen to provide feedback about operations. They automatically dismiss after a few seconds and can be positioned anywhere on the screen.
+
+To show a toast notification:
+
+1. Call `ui.show_toast()` within a reactive effect or event handler, typically triggered by a button click or other user action.
+
+2. For simple messages, pass a string directly: `ui.show_toast("Operation complete!")`.
+
+3. For more control, create a toast object with `ui.toast()` and pass it to `ui.show_toast()`. This allows you to specify the type, position, duration, header, and icon.
+
+**Toast Types**: Use the `type` parameter to color-code your messages:
+  - `"success"` - Green, for successful operations
+  - `"info"` - Blue, for informational messages
+  - `"warning"` - Yellow, for warnings
+  - `"danger"` or `"error"` - Red, for errors
+  - `"primary"`, `"secondary"`, `"light"`, `"dark"` - Other styling options
+
+**Positioning**: Toasts can appear in 9 positions using the `position` parameter:
+  - Top: `"top-left"`, `"top-center"`, `"top-right"` (default)
+  - Middle: `"middle-left"`, `"middle-center"`, `"middle-right"`
+  - Bottom: `"bottom-left"`, `"bottom-center"`, `"bottom-right"`
+
+**Auto-hide**: By default, toasts disappear after 5 seconds (`duration_s=5` seconds). Set `duration_s=None` to keep the toast visible until the user manually closes it.
+
+**Progress Bar**: Toasts include an animated progress bar that shows the remaining time before auto-hide.
+
+**Programmatic Control**: Use `ui.hide_toast(id)` to manually dismiss a toast. When creating a toast, specify an `id` parameter to reference it later.
+
+**Toasts vs Notifications**: Toasts are a more modern alternative to `ui.notification_show()` with more positioning options, types, and visual polish. For new applications, toasts are recommended.
+
+## Variations
+
+:::{#variations}
+:::

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe>=1.3.2,<2.0.0
+griffe

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe
+griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary
- Adds documentation for `ui.show_toast()` component
- Includes Express and Core examples with interactive previews
- Shows position variations and toast types
- Adds navigation entry to components sidebar

## Test plan
- [ ] Preview site renders correctly
- [ ] Toast examples work in Shinylive
- [ ] Position and type variations display correctly
- [ ] Navigation links to new component page

🤖 Generated with [Claude Code](https://claude.com/claude-code)