### PR TITLE
Add code-editor component documentation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -138,6 +138,7 @@ website:
             - components/inputs/action-link/index.qmd
             - components/inputs/checkbox/index.qmd
             - components/inputs/checkbox-group/index.qmd
+            - components/inputs/code-editor/index.qmd
             - components/inputs/dark-mode/index.qmd
             - components/inputs/date-range-selector/index.qmd
             - components/inputs/date-selector/index.qmd

--- a/components/inputs/code-editor/app-core.py
+++ b/components/inputs/code-editor/app-core.py
@@ -1,0 +1,13 @@
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.input_code_editor("code", "Enter Python code:", "print('Hello, world!')"), # <<
+    ui.output_code("code_output"),
+)
+
+def server(input, output, session):
+    @render.code
+    def code_output():
+        return input.code()
+
+app = App(app_ui, server)

--- a/components/inputs/code-editor/app-detail-preview.py
+++ b/components/inputs/code-editor/app-detail-preview.py
@@ -1,0 +1,19 @@
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.input_code_editor(
+        "code",
+        "Enter Python code:",
+        "# Write your Python code here\nprint('Hello, world!')",
+        language="python",
+        height="200px",
+    ),
+    ui.output_code("code_output"),
+)
+
+def server(input, output, session):
+    @render.code
+    def code_output():
+        return input.code()
+
+app = App(app_ui, server)

--- a/components/inputs/code-editor/app-express.py
+++ b/components/inputs/code-editor/app-express.py
@@ -1,0 +1,7 @@
+from shiny.express import input, render, ui
+
+ui.input_code_editor("code", "Enter Python code:", "print('Hello, world!')") # <<
+
+@render.code
+def code_output():
+    return input.code()

--- a/components/inputs/code-editor/app-preview.py
+++ b/components/inputs/code-editor/app-preview.py
@@ -1,0 +1,16 @@
+from shiny import ui, App
+
+app_ui = ui.page_fluid(
+    ui.input_code_editor(
+        "code",
+        "Code Editor",
+        "# Python code editor\nprint('Hello!')",
+        language="python",
+        height="150px",
+    ),
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)

--- a/components/inputs/code-editor/app-variation-languages-express.py
+++ b/components/inputs/code-editor/app-variation-languages-express.py
@@ -1,0 +1,27 @@
+from shiny.express import ui
+
+ui.h4("Different Programming Languages")
+
+ui.input_code_editor(
+    "python_code",
+    "Python",
+    "def hello():\n    print('Hello, Python!')",
+    language="python",
+    height="120px",
+)
+
+ui.input_code_editor(
+    "javascript_code",
+    "JavaScript",
+    "function hello() {\n  console.log('Hello, JavaScript!');\n}",
+    language="javascript",
+    height="120px",
+)
+
+ui.input_code_editor(
+    "sql_code",
+    "SQL",
+    "SELECT * FROM users\nWHERE active = true;",
+    language="sql",
+    height="100px",
+)

--- a/components/inputs/code-editor/app-variation-languages.py
+++ b/components/inputs/code-editor/app-variation-languages.py
@@ -1,0 +1,31 @@
+from shiny import ui, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Different Programming Languages"),
+    ui.input_code_editor(
+        "python_code",
+        "Python",
+        "def hello():\n    print('Hello, Python!')",
+        language="python",
+        height="120px",
+    ),
+    ui.input_code_editor(
+        "javascript_code",
+        "JavaScript",
+        "function hello() {\n  console.log('Hello, JavaScript!');\n}",
+        language="javascript",
+        height="120px",
+    ),
+    ui.input_code_editor(
+        "sql_code",
+        "SQL",
+        "SELECT * FROM users\nWHERE active = true;",
+        language="sql",
+        height="100px",
+    ),
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)

--- a/components/inputs/code-editor/app-variation-read-only-express.py
+++ b/components/inputs/code-editor/app-variation-read-only-express.py
@@ -1,0 +1,12 @@
+from shiny.express import ui
+
+ui.h4("Read-only Code Display")
+
+ui.input_code_editor(
+    "readonly_code",
+    "Example Code (Read-only)",
+    "# This code cannot be edited\ndef calculate_sum(a, b):\n    return a + b\n\nresult = calculate_sum(10, 20)\nprint(f'Result: {result}')",
+    language="python",
+    height="180px",
+    read_only=True,
+)

--- a/components/inputs/code-editor/app-variation-read-only.py
+++ b/components/inputs/code-editor/app-variation-read-only.py
@@ -1,0 +1,18 @@
+from shiny import ui, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Read-only Code Display"),
+    ui.input_code_editor(
+        "readonly_code",
+        "Example Code (Read-only)",
+        "# This code cannot be edited\ndef calculate_sum(a, b):\n    return a + b\n\nresult = calculate_sum(10, 20)\nprint(f'Result: {result}')",
+        language="python",
+        height="180px",
+        read_only=True,
+    ),
+)
+
+def server(input, output, session):
+    pass
+
+app = App(app_ui, server)

--- a/components/inputs/code-editor/index.qmd
+++ b/components/inputs/code-editor/index.qmd
@@ -1,0 +1,112 @@
+---
+title: Code Editor
+sidebar: components
+appPreview:
+  file: components/inputs/code-editor/app-preview.py
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/inputs/code-editor/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 350
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhXER0AVwpFhEACZwGRBZwA6EfTqzdFFAPpkNZuGs4VpACl1hLcZ0WcBRSpuQAFXAp2cmRXRHdkZyFuCgcAcgAJOAAbZNIiAHdpZLUAQjiASmcC5ABiZAAeCv19AAFVDQYsV30NOlDSK1IlUwcC8IhkIeRhCgUGQZMlZs64Pv1CVApcdAQUMCp+CjAAXwBdIA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAV05EG1ACZwGRAIKYAOhFUZ0AfXHIAvGM44oAczia6AG3HSAFKuQODWbulEVNZWZrjTOFIXZgnnDKhMihAKKUcsgACrgU7OTIwYihRKHoDNwUNgDkABJwFhakRADuQhbSAIR5AJSh9UQAxMgAPO32juJYpG6u7sGBwZr9FINNBKqNahCydGxyAG5yNi5uROODRKxwrKyc5PVpEI7IAAJS83JYwd0OCymkXttuNicP58hSFKIMZw2FDuLzgH1U6kwemQSnQNg02gkSwYqwYszCYAouHQCBQmLgAA8KGAAL4AXSAA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.input_code_editor
+    href: https://shiny.posit.co/py/api/ui.input_code_editor.html
+    signature: ui.input_code_editor(id, label=None, value='', *, language='plain',
+      height='auto', width='100%', theme_light='github-light', theme_dark='github-dark',
+      read_only=False, line_numbers=None, word_wrap=None, tab_size=4, indentation='space',
+      fill=True, **kwargs)
+  - title: ui.update_code_editor
+    href: https://shiny.posit.co/py/api/ui.update_code_editor.html
+    signature: ui.update_code_editor(id, *, label=None, value=None, language=None,
+      theme_light=None, theme_dark=None, read_only=None, line_numbers=None, word_wrap=None,
+      tab_size=None, indentation=None, session=None)
+- id: variations
+  template: ../../_partials/components-variations.ejs
+  template-params:
+    dir: components/inputs/code-editor/
+  contents:
+  - title: Different programming languages
+    description: 'The code editor supports syntax highlighting for many programming
+      languages including Python, JavaScript, R, SQL, HTML, CSS, JSON, Markdown, and
+      more. Set the `language` parameter to enable syntax highlighting for your preferred
+      language.
+
+      '
+    apps:
+    - title: Preview
+      file: app-variation-languages.py
+      height: 450
+    - title: Express
+      file: app-variation-languages-express.py
+    - title: Core
+      file: app-variation-languages.py
+  - title: Read-only display
+    description: 'Set `read_only=True` to display code that cannot be edited. This
+      is useful for showing example code or documentation.
+
+      '
+    apps:
+    - title: Preview
+      file: app-variation-read-only.py
+      height: 300
+    - title: Express
+      file: app-variation-read-only-express.py
+    - title: Core
+      file: app-variation-read-only.py
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A code editor input provides an interactive code editing experience with syntax highlighting, line numbers, and keyboard shortcuts. It's powered by [Prism Code Editor](https://prism-code-editor.netlify.app/) and supports many programming languages.
+
+To add a code editor to your app:
+
+1. Add `ui.input_code_editor()` to the UI of your app to create a code editor. Specify the `id` and `label` parameters. The `id` will be used to access the editor's value.
+
+2. Set the initial code with the `value` parameter. This can be a string or a list of strings (one per line).
+
+3. Specify the programming `language` for syntax highlighting. The editor supports many languages including `"python"`, `"javascript"`, `"r"`, `"sql"`, `"html"`, `"css"`, `"json"`, `"markdown"`, and more.
+
+The value of a code editor is accessible as a reactive value within the `server()` function. To access the value:
+
+1. Use `input.<code_editor_id>()` (e.g., `input.code()`) to access the current code as a string.
+
+**Value Updates**: Unlike text inputs that update on every keystroke, the code editor only sends its value to the server when:
+  - The user presses `Ctrl/Cmd + Enter`
+  - The editor loses focus (blur event)
+
+This reduces server load while editing code.
+
+**Keyboard Shortcuts**:
+  - `Ctrl/Cmd + Enter`: Submit code to server
+  - `Ctrl/Cmd + Z`: Undo
+  - `Ctrl/Cmd + Shift + Z`: Redo
+  - `Tab`: Indent selection
+  - `Shift + Tab`: Dedent selection
+
+**Dark Mode**: The editor automatically switches between `theme_light` and `theme_dark` themes when used with `ui.input_dark_mode()`.
+
+**Height and Sizing**: Set `height="auto"` to grow with content, or use a fixed height like `"300px"`. When `fill=True` (the default), the editor participates in fillable layouts and can expand to fill available space.
+
+## Variations
+
+:::{#variations}
+:::

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe>=1.3.2,<2.0.0
+griffe

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe
+griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary
- Adds documentation for `ui.input_code_editor()` component
- Includes Express and Core examples with interactive previews
- Shows language variations and read-only mode
- Adds navigation entry to components sidebar

## Test plan
- [ ] Preview site renders correctly
- [ ] Code editor examples work in Shinylive
- [ ] Language and read-only variations display correctly
- [ ] Navigation links to new component page

🤖 Generated with [Claude Code](https://claude.com/claude-code)