### PR TITLE
Add download-button component documentation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -141,6 +141,7 @@ website:
             - components/inputs/dark-mode/index.qmd
             - components/inputs/date-range-selector/index.qmd
             - components/inputs/date-selector/index.qmd
+            - components/inputs/download-button/index.qmd
             - components/inputs/file/index.qmd
             - components/inputs/numeric-input/index.qmd
             - components/inputs/password-field/index.qmd

--- a/components/inputs/download-button/app-core.py
+++ b/components/inputs/download-button/app-core.py
@@ -1,0 +1,15 @@
+from datetime import date
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.download_button("download_data", "Download CSV"), # <<
+)
+
+def server(input, output, session):
+    @render.download(filename=lambda: f"data-{date.today()}.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+app = App(app_ui, server)

--- a/components/inputs/download-button/app-detail-preview.py
+++ b/components/inputs/download-button/app-detail-preview.py
@@ -1,0 +1,18 @@
+from datetime import date
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Download Example Data"),
+    ui.download_button("download_data", "Download CSV File"),
+    ui.p("Click the button to download a CSV file with sample data."),
+)
+
+def server(input, output, session):
+    @render.download(filename=f"sample-data-{date.today()}.csv")
+    def download_data():
+        yield "name,age,city\n"
+        yield "Alice,25,New York\n"
+        yield "Bob,30,San Francisco\n"
+        yield "Charlie,35,Chicago\n"
+
+app = App(app_ui, server)

--- a/components/inputs/download-button/app-express.py
+++ b/components/inputs/download-button/app-express.py
@@ -1,0 +1,8 @@
+from datetime import date
+from shiny.express import render
+
+@render.download(filename=lambda: f"data-{date.today()}.csv") # <<
+def download_data():
+    yield "name,value\n"
+    yield "Alice,100\n"
+    yield "Bob,200\n"

--- a/components/inputs/download-button/app-preview.py
+++ b/components/inputs/download-button/app-preview.py
@@ -1,0 +1,13 @@
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.download_button("download", "Download"),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+def server(input, output, session):
+    @render.download(filename="data.csv")
+    def download():
+        yield "a,b,c\n1,2,3\n4,5,6"
+
+app = App(app_ui, server)

--- a/components/inputs/download-button/index.qmd
+++ b/components/inputs/download-button/index.qmd
@@ -1,0 +1,67 @@
+---
+title: Download Button
+sidebar: components
+appPreview:
+  file: components/inputs/download-button/app-preview.py
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/inputs/download-button/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 200
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAEyiooEt5kf1SDCmw5wAOhEbNkAZwAWXCLixwAHugZwZMvjAFDkmiKzgMJEgAJGTDLK1IB3CABtSUVgAo6XZ9VhwAXjoxMHYKKABaEDC4LApSdlwPAEoAXyxiGQA3EOTkAGJkAB4iiRM6NkcXN1YAfTCoFMQJZFbkXC44Z1ZkEOh4AiyoZwBXcXMwFraOrp6QgEFnLmI4AgBGAAYNsQmp1pnu3rAAIVIAIwIAJi2diBCJQlQKXHQEFDAqVQowVIBdIA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAEyiooEt5kf1SDCmw5wAOhEbNkAZwAWXCLj4wBQ5AFcuRBtVZwGRAIKYJEjOgD6W5AF5NXHFADmcS3QA2W1gAoJyAIcsVlIAdwgPUihWSwAjDQoKcj8wEPDI6Mt2CigxQmQ8gBEwiKjWZABhAGUANTyASiIAYmQAHlaJerMIfTpZAwA3Ax9FdASiUgSxiiIZOBkZLnJ6xH9AgAFdHoNgkozfOi4Palg4Wzo87KgAWhBsuCwk9lwfeoBfLGIZAYa1gN62HsylkOFBXqsIIEochcFw4B5ynloPACAMoF5xGYwH9obD4YiwEYPFxiHACABGAAMlLEWJxULxCIKYAAQqRYgQAEzU2kQPLdCx2ZAmdA+CzWbT9BhDBhdCD5MAUXDoBAoRVwAAeFDAbwAukA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.download_button
+    href: https://shiny.posit.co/py/api/ui.download_button.html
+    signature: ui.download_button(id, label, *, icon=None, width=None, **kwargs)
+  - title: ui.download_link
+    href: https://shiny.posit.co/py/api/ui.download_link.html
+    signature: ui.download_link(id, label, *, icon=None, width=None, **kwargs)
+  - title: '@render.download'
+    href: https://shiny.posit.co/py/api/render.download.html
+    signature: '@render.download(fn=None, *, filename=None, media_type=None, encoding="utf-8", label="Download")'
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A download button triggers a file download when clicked. Use `ui.download_button()` for a button style, or `ui.download_link()` for a link style.
+
+To add a download button to your app:
+
+1. Add `ui.download_button()` or `ui.download_link()` to the UI with a unique `id` and descriptive `label`. (In Express mode, the button is auto-generated from the function name.)
+
+2. Create a function with the same name as the button's `id` and decorate it with `@render.download()`.
+
+3. The download function can either:
+   - Return a string filepath (for existing files on disk)
+   - `yield` content line by line or chunk by chunk (for generated content or temp files)
+
+4. Specify the download filename using the `filename` parameter of `@render.download()`. This can be a string or a function that returns a string (useful for dynamic filenames).
+
+**Dynamic Filenames**: Use a lambda or function for the `filename` parameter to create dynamic filenames:
+
+```python
+@render.download(filename=lambda: f"data-{date.today()}.csv")
+```
+
+**Content Types**: The download handler can yield any content - CSV data, JSON, text files, images, or binary data. For binary files, yield bytes instead of strings.
+
+**Streaming**: The `yield` approach allows streaming large files efficiently without loading the entire file into memory.
+
+See Also: [Output UI](../../outputs/ui/index.qmd) can be used to dynamically generate download buttons based on user inputs or reactive values.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe>=1.3.2,<2.0.0
+griffe

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe
+griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary
- Adds documentation for `ui.download_button()` component
- Includes Express and Core examples with interactive previews
- Adds navigation entry to components sidebar

## Test plan
- [ ] Preview site renders correctly
- [ ] Download button examples work in Shinylive
- [ ] Navigation links to new component page

🤖 Generated with [Claude Code](https://claude.com/claude-code)