### PR TITLE
Add code output component documentation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -156,6 +156,7 @@ website:
             - components/inputs/text-box/index.qmd
         - section: "![](/images/bar-chart-line-fill.svg){.sidebar-icon .sidebar-subtitle}__Outputs__"
           contents:
+            - components/outputs/code/index.qmd
             - components/outputs/data-grid/index.qmd
             - components/outputs/data-table/index.qmd
             - components/outputs/image/index.qmd

--- a/components/outputs/code/app-core.py
+++ b/components/outputs/code/app-core.py
@@ -1,0 +1,12 @@
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.output_code("code_output"), # <<
+)
+
+def server(input, output, session):
+    @render.code
+    def code_output():
+        return "def hello():\n    print('Hello, world!')"
+
+app = App(app_ui, server)

--- a/components/outputs/code/app-detail-preview.py
+++ b/components/outputs/code/app-detail-preview.py
@@ -1,0 +1,30 @@
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.h4("Code Output Example"),
+    ui.output_code("python_code"),
+    ui.output_code("sql_code"),
+)
+
+def server(input, output, session):
+    @render.code
+    def python_code():
+        return """def calculate_sum(numbers):
+    total = 0
+    for num in numbers:
+        total += num
+    return total
+
+result = calculate_sum([1, 2, 3, 4, 5])
+print(f"Sum: {result}")"""
+
+    @render.code
+    def sql_code():
+        return """SELECT users.name, COUNT(orders.id) as order_count
+FROM users
+LEFT JOIN orders ON users.id = orders.user_id
+WHERE users.active = true
+GROUP BY users.name
+ORDER BY order_count DESC;"""
+
+app = App(app_ui, server)

--- a/components/outputs/code/app-express.py
+++ b/components/outputs/code/app-express.py
@@ -1,0 +1,5 @@
+from shiny.express import render
+
+@render.code # <<
+def code_output():
+    return "def hello():\n    print('Hello, world!')"

--- a/components/outputs/code/app-preview.py
+++ b/components/outputs/code/app-preview.py
@@ -1,0 +1,13 @@
+from shiny import ui, render, App
+
+app_ui = ui.page_fluid(
+    ui.output_code("code"),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+def server(input, output, session):
+    @render.code
+    def code():
+        return "print('Hello, world!')"
+
+app = App(app_ui, server)

--- a/components/outputs/code/index.qmd
+++ b/components/outputs/code/index.qmd
@@ -1,0 +1,67 @@
+---
+title: Code
+sidebar: components
+appPreview:
+  file: components/outputs/code/app-preview.py
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/outputs/code/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 400
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhWTCIAEzgMAOhDUABeUoZYyS5AGJkAHhNqldZPrgB9UgFcK6JwAoAlIjXIfcuBQcGCGQVMEtkdjgAGyjSDy9vXyFuClcAcgAJaNiiAHdpKIUAQjT3ULVCVApcdAQUMCp+CjAAXwBdIA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAV05EG1ACZwGRAIKYAOhFUZ0AfXHIAvGM44oAczia6AG3HSAFKuQODWUqIrpXmsrLtgvZl26uymAAlEQAxMgAPFGqIaqqsnRscgBucjbc7hREAdlErHCsrJzkIYj2jgACUhCyDFh+lQ5JyH6aea425c2ODlIUogwQyMGt7HAWFqTdFb3oDNwUNgDkABKT00QA7kIW0gCEK-FgCdCYeshK6DYa2hIpDOkM8RCEqBS46AgoYFQAHhQwABfAC6QA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: '@render.code'
+    href: https://shiny.posit.co/py/api/render.code.html
+    signature: '@render.code(_fn=None, *, placeholder=True)'
+  - title: ui.output_code
+    href: https://shiny.posit.co/py/api/ui.output_code.html
+    signature: ui.output_code(id, placeholder=True)
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A code output displays formatted code in a monospace font within a bordered container. It's similar to verbatim text output but specifically designed for displaying code.
+
+To add code output to your app:
+
+1. Add `ui.output_code()` to the UI, providing a unique `id`.
+
+2. In the server function, define a function with the same name as the output `id` and decorate it with `@render.code`.
+
+3. Return a string containing the code to display. Use `\n` for line breaks or return multi-line strings with triple quotes.
+
+The output appears in a monospace font within a bordered, slightly shaded container that clearly identifies it as code.
+
+**Formatting**: The code renderer automatically:
+  - Uses monospace font
+  - Preserves whitespace and indentation
+  - Shows line breaks exactly as formatted
+  - Wraps in a bordered container
+
+**Use Cases**:
+  - Displaying generated code snippets
+  - Showing SQL queries
+  - Presenting configuration files
+  - Displaying command-line instructions
+  - Showing code examples or templates
+
+**Dynamic Code**: The render function can generate code dynamically based on user inputs, allowing you to build code generators, query builders, or configuration tools.
+
+See Also: [Verbatim Text](../verbatim-text/index.qmd) provides similar monospace output but without the code-specific styling context.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe>=1.3.2,<2.0.0
+griffe

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyter
 jupyter_client < 8.0.0
 tabulate
 shinylive==0.8.5
-griffe
+griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary
- Adds documentation for `output_code()` / `render.code` component
- Includes Express and Core examples with interactive previews
- Shows syntax-highlighted code output display
- Adds navigation entry to components sidebar

## Test plan
- [ ] Preview site renders correctly
- [ ] Code output examples work in Shinylive
- [ ] Navigation links to new component page

🤖 Generated with [Claude Code](https://claude.com/claude-code)