### PR TITLE
chore: Update py-shiny to v1.6.1 and shinylive to 0.8.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.8.5
+shinylive==0.8.7
 # Pinned to <2.0.0 due to compatibility issues with quartodoc
 # See: https://github.com/posit-dev/py-shiny/commit/c2e4b204
 griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary

* Update py-shiny submodule from v1.5.1 to v1.6.1
* Update shinylive from 0.8.5 to 0.8.7 in requirements.txt

Part of the py-shiny v1.6.1 release train.