### PR TITLE
chore: Bump py-shiny submodule to v1.6.2 and shinylive to 0.8.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.8.7
+shinylive==0.8.8
 # Pinned to <2.0.0 due to compatibility issues with quartodoc
 # See: https://github.com/posit-dev/py-shiny/commit/c2e4b204
 griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
## Summary

Phase 10 of the v1.6.2 release train.

- `py-shiny` submodule → **v1.6.2** (`3a4dcb64`)
- `requirements.txt`: `shinylive==0.8.7` → `shinylive==0.8.8`

## Verify on deployment preview

- [ ] API docs (`api/core/`, `api/express/`, `api/testing/`) render correctly
- [ ] Examples / shinylive embeds run

See posit-dev/py-shiny#2248 for the release.