### PR TITLE
fix: update ipyleaflet component page with working links and accurate API docs

### DIFF
--- a/components/outputs/map-ipyleaflet/index.qmd
+++ b/components/outputs/map-ipyleaflet/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/outputs/map-ipyleaflet/
   contents:
   - title: shinywidgets.output_widget
-    href: map-ipyleaflet.html#details
-    signature: null
-  - title: shinywidgets.register_widget
-    href: map-ipyleaflet.html#details
-    signature: null
+    href: https://github.com/posit-dev/py-shinywidgets/blob/main/shinywidgets/_output_widget.py
+    signature: shinywidgets.output_widget(id, *, width, height, fill, fillable)
+  - title: '@shinywidgets.render_widget()'
+    href: https://github.com/posit-dev/py-shinywidgets/blob/main/shinywidgets/_render_widget.py
+    signature: shinywidgets.render_widget(fn)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:
@@ -61,19 +61,13 @@ listing:
 
 ## Details
 
-`ipyleaflet` allows us to create interactive maps via [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/).
+`ipyleaflet` provides interactive maps via [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/). To insert one, write a function that returns a `Map(...)` and decorate it with `@shinywidgets.render_widget`.
 
-To insert an `ipyleaflet` map do the following tasks:
+**Shiny Express:** the decorated function renders in place — its position in the script determines where the map appears.
 
-  1. Add `shinywidgets.output_widget()` to the UI of your app to create a div in which to display the map.   Where you call this function will determine where the map will appear within the layout of the app.
+**Shiny Core:** add `shinywidgets.output_widget("id")` to your UI as a placeholder, then define the decorated function inside `server()` using the same name as `id`.
 
-  2. Provide an argument to the `id` parameter in the `shinywidgets.output_widget()` function call. This argument will be used to identify the map in the server function.
-
-  3. Within the `server()` function, create your `ipyleaflet` map and assign it to a variable.   Your map does not need to be created within a nested function in server() like many other shiny for python components.
-
-  4. Register your map with shiny using `shinywidgets.register_widget()` by passing in the id of the map and the map variable.
-
- Visit [shiny.posit.co/py/docs/ipywidgets.html](https://shiny.posit.co/py/docs/ipywidgets.html) to learn more about using ipywidgets with Shiny.
+Visit the [Jupyter Widgets](/docs/jupyter-widgets.html) docs to learn more.
 
 ## Variations
 

--- a/components/outputs/map-ipyleaflet/index.qmd
+++ b/components/outputs/map-ipyleaflet/index.qmd
@@ -63,9 +63,9 @@ listing:
 
 `ipyleaflet` provides interactive maps via [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/). To insert one, write a function that returns a `Map(...)` and decorate it with `@shinywidgets.render_widget`.
 
-**Shiny Express:** the decorated function renders in place — its position in the script determines where the map appears.
+**Shiny Express:** The decorated function renders in place — its position in the script determines where the map appears.
 
-**Shiny Core:** add `shinywidgets.output_widget("id")` to your UI as a placeholder, then define the decorated function inside `server()` using the same name as `id`.
+**Shiny Core:** Add `shinywidgets.output_widget("id")` to your UI as a placeholder, then define the decorated function inside `server()` using the same name as `id`.
 
 Visit the [Jupyter Widgets](/docs/jupyter-widgets.html) docs to learn more.
 

--- a/components/outputs/map-ipyleaflet/index.qmd
+++ b/components/outputs/map-ipyleaflet/index.qmd
@@ -24,10 +24,10 @@ listing:
     dir: components/outputs/map-ipyleaflet/
   contents:
   - title: shinywidgets.output_widget
-    href: https://github.com/posit-dev/py-shinywidgets/blob/main/shinywidgets/_output_widget.py
+    href: https://github.com/posit-dev/py-shinywidgets/blob/main/shinywidgets/_output_widget.py#L16
     signature: shinywidgets.output_widget(id, *, width, height, fill, fillable)
   - title: '@shinywidgets.render_widget()'
-    href: https://github.com/posit-dev/py-shinywidgets/blob/main/shinywidgets/_render_widget.py
+    href: https://github.com/posit-dev/py-shinywidgets/blob/main/shinywidgets/_render_widget.py#L29
     signature: shinywidgets.render_widget(fn)
 - id: variations
   template: ../../_partials/components-variations.ejs


### PR DESCRIPTION
Fixes #371 
## Summary

- Replaces broken internal anchor links (`map-ipyleaflet.html#details`) with direct GitHub source links for `output_widget` and `render_widget`
- Updates the API listing to reflect the current `@shinywidgets.render_widget` decorator pattern (replacing the deprecated `register_widget` approach)
- Rewrites the Details section to be concise and consistent with how other component pages document Express vs. Core usage patterns
- Fixes the internal link to the Jupyter Widgets docs page

## Test plan

- [x] Verify the GitHub source links resolve correctly
- [x] Verify the `/docs/jupyter-widgets.html` link resolves on the built site
- [x] Spot-check the rendered component page looks correct