### PR TITLE
Update py-shiny to v1.6.3 and shinylive to 0.8.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.8.8
+shinylive==0.8.9
 # Pinned to <2.0.0 due to compatibility issues with quartodoc
 # See: https://github.com/posit-dev/py-shiny/commit/c2e4b204
 griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
Updates the docs site for the **py-shiny v1.6.3** release.

- `py-shiny` submodule → **v1.6.3**
- `shinylive` → **0.8.9** in requirements.txt

Will verify API docs + examples via the deploy preview before merging.

Part of the py-shiny v1.6.3 release train. See posit-dev/py-shiny#2266.