### PR TITLE
docs(otel): Document zero-code auto-instrumentation (opentelemetry-instrument)

### DIFF
--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -130,13 +130,8 @@ provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
 trace.set_tracer_provider(provider)
 
 # Then write your app as usual
-from shiny.express import input, render, ui
-
-ui.input_slider("n", "N", 1, 100, 50)
-
-@render.text
-def result():
-    return f"You selected: {input.n()}"
+from shiny.express import ui, render
+# ...
 ```
 
 **Run** the app directly — no wrapper:

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -10,18 +10,32 @@ To simplify things, we'll use Logfire as our example observability backend for c
 
 ::: {.panel-tabset}
 
-## Console (no backend)
+## Zero-code (default)
 
-For local debugging without an observability backend, print spans to the console. First install `shiny[otel]`:
+All configuration lives in the launch command; your app contains no instrumentation code.
+
+**Setup**
 
 ```bash
 uv add "shiny[otel]"
 ```
 
-Then run your app under the wrapper — no app-code changes needed:
+**App** — write your app as usual, with no OpenTelemetry code:
+
+```{.python filename="app.py"}
+from shiny.express import input, render, ui
+
+ui.input_slider("n", "N", 1, 100, 50)
+
+@render.text
+def result():
+    return f"You selected: {input.n()}"
+```
+
+**Run** the app under the [`opentelemetry-instrument`](https://opentelemetry.io/docs/zero-code/python/) wrapper:
 
 ```bash
-# Print spans to the console (local debugging)
+# Print spans to the console (local debugging, no backend needed)
 uv run opentelemetry-instrument --traces_exporter console shiny run app.py
 
 # Or export over OTLP (the default) to a local collector or backend
@@ -33,6 +47,48 @@ Everything is configurable through standard [OpenTelemetry environment variables
 - Set `OTEL_SERVICE_NAME`; otherwise traces report `service.name: unknown_service`.
 - Auto-instrumentation also instruments other libraries your app uses (HTTP clients, databases, etc.), so their spans appear alongside Shiny's.
 - `shiny run --reload` works; the reloaded process inherits the instrumentation.
+
+## Code-based
+
+If you can't control the launch command (or prefer explicit configuration), configure the SDK in your app code instead.
+
+**Setup**
+
+```bash
+# Option 1: Install with Shiny's optional dependencies
+uv add "shiny[otel]"
+
+# Option 2: Install the SDK manually
+uv add opentelemetry-sdk opentelemetry-exporter-otlp
+```
+
+**App** — configure the tracer provider before importing Shiny:
+
+```{.python filename="app.py"}
+# Configure OpenTelemetry before importing Shiny
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
+
+# Then write your app as usual
+from shiny.express import input, render, ui
+
+ui.input_slider("n", "N", 1, 100, 50)
+
+@render.text
+def result():
+    return f"You selected: {input.n()}"
+```
+
+**Run** the app directly — no wrapper:
+
+```bash
+uv run shiny run app.py
+```
 
 ::: {.callout-tip}
 ## Prefer zero-code over code-based setup
@@ -94,7 +150,7 @@ See the [Logfire documentation](https://logfire.pydantic.dev/) for more details 
 
 To keep your app efficient, it's helpful to move OpenTelemetry setup into a dedicated module. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
 
-This pattern applies to in-code configuration only (e.g. the *Logfire* tab above, whose SDK manages OpenTelemetry itself). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
+This pattern applies to in-code configuration only (the *Code-based* and *Logfire* tabs above). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
 
 You'll notice our `otel_config` module includes setting `SHINY_OTEL_COLLECT`. This variable controls how much detail is captured and defaults to `"all"`.
 

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -145,22 +145,11 @@ def result():
 uv run shiny run app.py
 ```
 
-::: {.callout-tip}
-## Prefer zero-code over code-based setup
-
-OpenTelemetry supports both [zero-code and code-based instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/). Prefer zero-code when you can: keeping configuration in the launch command lets each environment behave differently — a hosted deployment can export OTLP to its collector while your local run prints to the console — without changing the app.
-
-Whichever you choose, configure OpenTelemetry in one place. A tracer provider can only be installed once per process, so a code-based call like `trace.set_tracer_provider(...)` running under `opentelemetry-instrument` logs `Overriding of current TracerProvider is not allowed` and is ignored.
-:::
-
-:::
-
-
-#### Extract setup logic into a configuration module
+### Extract setup logic into a configuration module
 
 To keep your app efficient, it's helpful to move OpenTelemetry setup into a dedicated module. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
 
-This pattern applies to in-code configuration only (the *Code-based* tab and the `logfire` SDK setup above). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
+Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
 
 You'll notice our `otel_config` module includes setting `SHINY_OTEL_COLLECT`. This variable controls how much detail is captured and defaults to `"all"`.
 
@@ -180,4 +169,14 @@ import otel_config  # runs configuration as a side effect
 from shiny.express import ui, render
 # ...
 ```
+
+::: {.callout-tip}
+## Prefer zero-code over code-based setup
+
+OpenTelemetry supports both [zero-code and code-based instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/). Prefer zero-code when you can: keeping configuration in the launch command lets each environment behave differently — a hosted deployment can export OTLP to its collector while your local run prints to the console — without changing the app.
+
+Whichever you choose, configure OpenTelemetry in one place. A tracer provider can only be installed once per process, so a code-based call like `trace.set_tracer_provider(...)` running under `opentelemetry-instrument` logs `Overriding of current TracerProvider is not allowed` and is ignored.
+:::
+
+:::
 

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -48,6 +48,61 @@ Everything is configurable through standard [OpenTelemetry environment variables
 - Auto-instrumentation also instruments other libraries your app uses (HTTP clients, databases, etc.), so their spans appear alongside Shiny's.
 - `shiny run --reload` works; the reloaded process inherits the instrumentation.
 
+### Logfire (Observability Backend Service)
+
+[Pydantic Logfire](https://logfire.pydantic.dev/) provides zero-configuration OpenTelemetry setup with a managed observability platform. You will need to set up a Logfire account and project.
+
+Logfire is a standard OTLP backend, so `opentelemetry-instrument` can export to it with only environment variables and a [write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/):
+
+```bash
+export OTEL_SERVICE_NAME=my-shiny-app
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf  # Logfire speaks OTLP over HTTP, not gRPC
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://logfire-us.pydantic.dev"  # or logfire-eu
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=$LOGFIRE_TOKEN"
+uv run opentelemetry-instrument shiny run app.py
+```
+
+Alternatively, the `logfire` SDK manages OpenTelemetry itself (a code-based setup). On your first run of logfire, it will ask you to authenticate and choose which project your metrics will be associated with.
+
+```bash
+uv add logfire
+uv run logfire auth
+```
+
+::: {.callout-tip collapse="true"}
+## Test your Logfire setup with a simple app
+
+```python
+import logfire
+import os
+
+# Connect your app to the logfire backend so it can receive traces
+logfire.configure()
+
+# Import Shiny and set collection level
+from shiny import App, ui, render
+os.environ["SHINY_OTEL_COLLECT"] = "reactivity"
+
+# Use Shiny normally - tracing happens automatically
+app_ui = ui.page_fluid(
+    ui.input_slider("n", "N", 1, 100, 50),
+    ui.output_text("result")
+)
+
+def server(input, output, session):
+    @render.text
+    def result():
+        return f"You selected: {input.n()}"
+
+app = App(app_ui, server)
+```
+
+:::
+
+View traces at [logfire.pydantic.dev](https://logfire.pydantic.dev/) - you'll see session spans, reactive updates, and individual reactive executions with SQL-queryable data.
+
+See the [Logfire documentation](https://logfire.pydantic.dev/) for more details on querying, alerts, and dashboards.
+
 ## Code-based
 
 If you can't control the launch command (or prefer explicit configuration), configure the SDK in your app code instead.
@@ -98,63 +153,6 @@ OpenTelemetry supports both [zero-code and code-based instrumentation](https://o
 Whichever you choose, configure OpenTelemetry in one place. A tracer provider can only be installed once per process, so a code-based call like `trace.set_tracer_provider(...)` running under `opentelemetry-instrument` logs `Overriding of current TracerProvider is not allowed` and is ignored.
 :::
 
-## Logfire (Observability Backend Service)
-
-[Pydantic Logfire](https://logfire.pydantic.dev/) provides zero-configuration OpenTelemetry setup with a managed observability platform. You will need to set up a Logfire account and project.
-
-**Zero-code** — Logfire is a standard OTLP backend, so `opentelemetry-instrument` can export to it with only environment variables and a [write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/):
-
-```bash
-export OTEL_SERVICE_NAME=my-shiny-app
-export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf  # Logfire speaks OTLP over HTTP, not gRPC
-export OTEL_EXPORTER_OTLP_ENDPOINT="https://logfire-us.pydantic.dev"  # or logfire-eu
-export OTEL_EXPORTER_OTLP_HEADERS="Authorization=$LOGFIRE_TOKEN"
-uv run opentelemetry-instrument shiny run app.py
-```
-
-**Code-based** — alternatively, use the `logfire` SDK, which manages OpenTelemetry itself. On your first run of logfire, it will ask you to authenticate and choose which project your metrics will be associated with.
-
-```bash
-uv add logfire
-uv run logfire auth
-```
-
-
-
-::: {.callout-tip collapse="true"}
-## Test your Logfire setup with a simple app
-
-```python
-import logfire
-import os
-
-# Connect your app to the logfire backend so it can receive traces
-logfire.configure()
-
-# Import Shiny and set collection level
-from shiny import App, ui, render
-os.environ["SHINY_OTEL_COLLECT"] = "reactivity"
-
-# Use Shiny normally - tracing happens automatically
-app_ui = ui.page_fluid(
-    ui.input_slider("n", "N", 1, 100, 50),
-    ui.output_text("result")
-)
-
-def server(input, output, session):
-    @render.text
-    def result():
-        return f"You selected: {input.n()}"
-
-app = App(app_ui, server)
-```
-
-:::
-
-View traces at [logfire.pydantic.dev](https://logfire.pydantic.dev/) - you'll see session spans, reactive updates, and individual reactive executions with SQL-queryable data.
-
-See the [Logfire documentation](https://logfire.pydantic.dev/) for more details on querying, alerts, and dashboards.
-
 :::
 
 
@@ -162,7 +160,7 @@ See the [Logfire documentation](https://logfire.pydantic.dev/) for more details 
 
 To keep your app efficient, it's helpful to move OpenTelemetry setup into a dedicated module. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
 
-This pattern applies to in-code configuration only (the *Code-based* and *Logfire* tabs above). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
+This pattern applies to in-code configuration only (the *Code-based* tab and the `logfire` SDK setup above). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
 
 You'll notice our `otel_config` module includes setting `SHINY_OTEL_COLLECT`. This variable controls how much detail is captured and defaults to `"all"`.
 

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -100,7 +100,19 @@ Whichever you choose, configure OpenTelemetry in one place. A tracer provider ca
 
 ## Logfire (Observability Backend Service)
 
-[Pydantic Logfire](https://logfire.pydantic.dev/) provides zero-configuration OpenTelemetry setup with a managed observability platform. You will need to set up a Logfire account and project. On your first run of logfire, it will ask you to authenticate and choose which project your metrics will be associated with.
+[Pydantic Logfire](https://logfire.pydantic.dev/) provides zero-configuration OpenTelemetry setup with a managed observability platform. You will need to set up a Logfire account and project.
+
+**Zero-code** — Logfire is a standard OTLP backend, so `opentelemetry-instrument` can export to it with only environment variables and a [write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/):
+
+```bash
+export OTEL_SERVICE_NAME=my-shiny-app
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf  # Logfire speaks OTLP over HTTP, not gRPC
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://logfire-us.pydantic.dev"  # or logfire-eu
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=$LOGFIRE_TOKEN"
+uv run opentelemetry-instrument shiny run app.py
+```
+
+**Code-based** — alternatively, use the `logfire` SDK, which manages OpenTelemetry itself. On your first run of logfire, it will ask you to authenticate and choose which project your metrics will be associated with.
 
 ```bash
 uv add logfire

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -161,6 +161,8 @@ See the [Logfire documentation](https://logfire.pydantic.dev/) for more details 
 
 To keep your app efficient, it's helpful to move OpenTelemetry setup into a dedicated module. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
 
+This pattern applies to in-code configuration (the *Console-only* and *Logfire* tabs above). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
+
 You'll notice our `otel_config` module includes setting `SHINY_OTEL_COLLECT`. This variable controls how much detail is captured and defaults to `"all"`.
 
 You may want to reduce or refine your own collection level. Se the portion on [collection levels](#what-can-shiny-record) for more information.

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -117,23 +117,6 @@ uv add "shiny[otel]"
 uv add opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
-**App** — configure the tracer provider before importing Shiny:
-
-```{.python filename="app.py"}
-# Configure OpenTelemetry before importing Shiny
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
-
-provider = TracerProvider()
-provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
-trace.set_tracer_provider(provider)
-
-# Then write your app as usual
-from shiny.express import ui, render
-# ...
-```
-
 **Run** the app directly — no wrapper:
 
 ```bash
@@ -142,7 +125,7 @@ uv run shiny run app.py
 
 ### Extract setup logic into a configuration module
 
-To keep your app efficient, it's helpful to move OpenTelemetry setup into a dedicated module. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
+To keep your app efficient, move OpenTelemetry setup into a dedicated module that is imported before `shiny` is imported. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
 
 Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
 
@@ -168,7 +151,7 @@ from shiny.express import ui, render
 ::: {.callout-tip}
 ## Prefer zero-code over code-based setup
 
-OpenTelemetry supports both [zero-code and code-based instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/). Prefer zero-code when you can: keeping configuration in the launch command lets each environment behave differently — a hosted deployment can export OTLP to its collector while your local run prints to the console — without changing the app.
+OpenTelemetry supports both [zero-code and code-based instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/). Prefer zero-code when you can: keeping configuration in the launch command lets each environment behave differently — a hosted deployment (e.g. [Posit Connect](https://posit.co/products/enterprise/connect)) can export OTLP to its collector while your local run prints to the console — without changing the app.
 
 Whichever you choose, configure OpenTelemetry in one place. A tracer provider can only be installed once per process, so a code-based call like `trace.set_tracer_provider(...)` running under `opentelemetry-instrument` logs `Overriding of current TracerProvider is not allowed` and is ignored.
 :::

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -34,10 +34,12 @@ Everything is configurable through standard [OpenTelemetry environment variables
 - Auto-instrumentation also instruments other libraries your app uses (HTTP clients, databases, etc.), so their spans appear alongside Shiny's.
 - `shiny run --reload` works; the reloaded process inherits the instrumentation.
 
-::: {.callout-warning}
-## Don't configure OpenTelemetry inside the app
+::: {.callout-tip}
+## Prefer zero-code over code-based setup
 
-Configuring providers in app code (`trace.set_tracer_provider(...)`) is discouraged: it couples your app to one observability setup and conflicts with external instrumentation. Providers can only be installed once per process, so under `opentelemetry-instrument` an in-code call logs `Overriding of current TracerProvider is not allowed` and is silently ignored. Configure OpenTelemetry in exactly one place — the launch command (preferred) or, when using an SDK like Logfire that manages OpenTelemetry itself, that SDK's own setup.
+OpenTelemetry supports both [zero-code and code-based instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/). Prefer zero-code when you can: keeping configuration in the launch command lets each environment behave differently — a hosted deployment can export OTLP to its collector while your local run prints to the console — without changing the app.
+
+Whichever you choose, configure OpenTelemetry in one place. A tracer provider can only be installed once per process, so a code-based call like `trace.set_tracer_provider(...)` running under `opentelemetry-instrument` logs `Overriding of current TracerProvider is not allowed` and is ignored.
 :::
 
 ## Logfire (Observability Backend Service)

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -4,15 +4,57 @@
 
 You can use OTel with or without an observability backend (e.g. Logfire, Jaeger, Langfuse, etc.)
 
-For local debugging or use without an observability backend, you can configure OpenTelemetry to print spans to the console. You will need to install the OpenTelemetry SDK for this.
+For local debugging or use without an observability backend, you can configure OpenTelemetry to print spans to the console. Installing `shiny[otel]` provides the OpenTelemetry SDK, the OTLP exporters, and the `opentelemetry-instrument` auto-instrumentation wrapper.
 
 To simplify things, we'll use Logfire as our example observability backend for configuration and screenshots throughout the rest of this tutorial.
 
 ::: {.panel-tabset}
 
+## Auto-instrumentation (zero-code)
+
+The standard OpenTelemetry way to instrument a Python app is the [`opentelemetry-instrument`](https://opentelemetry.io/docs/zero-code/python/) wrapper, which configures the SDK before your app starts — no code changes needed. It ships with `shiny[otel]`.
+
+::: {.panel-tabset}
+
+## pip
+
+```bash
+pip install "shiny[otel]"
+```
+
+## uv
+
+```bash
+uv add "shiny[otel]"
+```
+
+:::
+
+Run your app under the wrapper:
+
+```bash
+# Print spans to the console (local debugging)
+opentelemetry-instrument --traces_exporter console shiny run app.py
+
+# Or export over OTLP (the default) to a local collector or backend
+OTEL_SERVICE_NAME=my-shiny-app opentelemetry-instrument shiny run app.py
+```
+
+Everything is configurable through standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/languages/sdk-configuration/) or CLI flags. A few tips:
+
+- Set `OTEL_SERVICE_NAME`; otherwise traces report `service.name: unknown_service`.
+- Auto-instrumentation also instruments other libraries your app uses (HTTP clients, databases, etc.), so their spans appear alongside Shiny's.
+- `shiny run --reload` works; the reloaded process inherits the instrumentation.
+
+::: {.callout-warning}
+## Don't mix with in-code SDK setup
+
+When running under `opentelemetry-instrument`, do not also call `trace.set_tracer_provider()` in your app (as shown in the *Console-only* tab). The wrapper installs the tracer provider before your app code runs, so the manual call logs `Overriding of current TracerProvider is not allowed` and is ignored. Pick one approach.
+:::
+
 ## Console-only
 
-You can use `pip` or `uv` to add the OTel SDK using `shiny`'s optional dependencies or install it independently.
+If you prefer configuring OpenTelemetry in code (when running the app directly with `shiny run app.py`, without `opentelemetry-instrument`), you can use `pip` or `uv` to add the OTel SDK using `shiny`'s optional dependencies or install it independently.
 
 ::: {.panel-tabset}
 

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -14,30 +14,18 @@ To simplify things, we'll use Logfire as our example observability backend for c
 
 For local debugging without an observability backend, print spans to the console. First install `shiny[otel]`:
 
-::: {.panel-tabset}
-
-## pip
-
-```bash
-pip install "shiny[otel]"
-```
-
-## uv
-
 ```bash
 uv add "shiny[otel]"
 ```
-
-:::
 
 Then run your app under the wrapper — no app-code changes needed:
 
 ```bash
 # Print spans to the console (local debugging)
-opentelemetry-instrument --traces_exporter console shiny run app.py
+uv run opentelemetry-instrument --traces_exporter console shiny run app.py
 
 # Or export over OTLP (the default) to a local collector or backend
-OTEL_SERVICE_NAME=my-shiny-app opentelemetry-instrument shiny run app.py
+OTEL_SERVICE_NAME=my-shiny-app uv run opentelemetry-instrument shiny run app.py
 ```
 
 Everything is configurable through standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/languages/sdk-configuration/) or CLI flags. A few tips:
@@ -56,23 +44,10 @@ Configuring providers in app code (`trace.set_tracer_provider(...)`) is discoura
 
 [Pydantic Logfire](https://logfire.pydantic.dev/) provides zero-configuration OpenTelemetry setup with a managed observability platform. You will need to set up a Logfire account and project. On your first run of logfire, it will ask you to authenticate and choose which project your metrics will be associated with.
 
-::: {.panel-tabset}
-
-## pip
-
-```bash
-pip install logfire
-logfire auth
-```
-
-## uv
-
 ```bash
 uv add logfire
 uv run logfire auth
 ```
-
-:::
 
 
 

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -4,15 +4,15 @@
 
 You can use OTel with or without an observability backend (e.g. Logfire, Jaeger, Langfuse, etc.)
 
-For local debugging or use without an observability backend, you can configure OpenTelemetry to print spans to the console. Installing `shiny[otel]` provides the OpenTelemetry SDK, the OTLP exporters, and the `opentelemetry-instrument` auto-instrumentation wrapper.
+The standard way to enable OpenTelemetry is the [`opentelemetry-instrument`](https://opentelemetry.io/docs/zero-code/python/) wrapper (zero-code auto-instrumentation), which configures the SDK before your app starts — your app contains no instrumentation code at all. Installing `shiny[otel]` provides the OpenTelemetry SDK, the OTLP exporters, and the wrapper.
 
 To simplify things, we'll use Logfire as our example observability backend for configuration and screenshots throughout the rest of this tutorial.
 
 ::: {.panel-tabset}
 
-## Auto-instrumentation (zero-code)
+## Console (no backend)
 
-The standard OpenTelemetry way to instrument a Python app is the [`opentelemetry-instrument`](https://opentelemetry.io/docs/zero-code/python/) wrapper, which configures the SDK before your app starts — no code changes needed. It ships with `shiny[otel]`.
+For local debugging without an observability backend, print spans to the console. First install `shiny[otel]`:
 
 ::: {.panel-tabset}
 
@@ -30,7 +30,7 @@ uv add "shiny[otel]"
 
 :::
 
-Run your app under the wrapper:
+Then run your app under the wrapper — no app-code changes needed:
 
 ```bash
 # Print spans to the console (local debugging)
@@ -47,54 +47,10 @@ Everything is configurable through standard [OpenTelemetry environment variables
 - `shiny run --reload` works; the reloaded process inherits the instrumentation.
 
 ::: {.callout-warning}
-## Don't mix with in-code SDK setup
+## Don't configure OpenTelemetry inside the app
 
-When running under `opentelemetry-instrument`, do not also call `trace.set_tracer_provider()` in your app (as shown in the *Console-only* tab). The wrapper installs the tracer provider before your app code runs, so the manual call logs `Overriding of current TracerProvider is not allowed` and is ignored. Pick one approach.
+Configuring providers in app code (`trace.set_tracer_provider(...)`) is discouraged: it couples your app to one observability setup and conflicts with external instrumentation. Providers can only be installed once per process, so under `opentelemetry-instrument` an in-code call logs `Overriding of current TracerProvider is not allowed` and is silently ignored. Configure OpenTelemetry in exactly one place — the launch command (preferred) or, when using an SDK like Logfire that manages OpenTelemetry itself, that SDK's own setup.
 :::
-
-## Console-only
-
-If you prefer configuring OpenTelemetry in code (when running the app directly with `shiny run app.py`, without `opentelemetry-instrument`), you can use `pip` or `uv` to add the OTel SDK using `shiny`'s optional dependencies or install it independently.
-
-::: {.panel-tabset}
-
-## pip
-
-```bash
-# Option 1: Install with Shiny's optional dependencies
-pip install "shiny[otel]"
-
-# Option 2: Install the SDK manually
-pip install opentelemetry-sdk opentelemetry-exporter-otlp
-```
-
-## uv
-
-```bash
-# Option 1: Install with Shiny's optional dependencies
-uv add "shiny[otel]"
-
-# Option 2: Install the SDK manually
-uv add opentelemetry-sdk opentelemetry-exporter-otlp
-```
-
-:::
-
-To add it to your app:
-
-```python
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
-
-provider = TracerProvider()
-provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
-trace.set_tracer_provider(provider)
-
-# Import and use Shiny normally
-from shiny import App, ui
-```
-
 
 ## Logfire (Observability Backend Service)
 
@@ -161,7 +117,7 @@ See the [Logfire documentation](https://logfire.pydantic.dev/) for more details 
 
 To keep your app efficient, it's helpful to move OpenTelemetry setup into a dedicated module. This keeps your app files clean and ensures configuration (environment variables, Logfire, AI instrumentation) is applied consistently before Shiny imports.
 
-This pattern applies to in-code configuration (the *Console-only* and *Logfire* tabs above). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
+This pattern applies to in-code configuration only (e.g. the *Logfire* tab above, whose SDK manages OpenTelemetry itself). Remember that OpenTelemetry should be configured in exactly one place: if you launch your app with `opentelemetry-instrument`, skip the configuration module — a tracer provider can only be installed once per process, and later in-code setup is ignored with a warning.
 
 You'll notice our `otel_config` module includes setting `SHINY_OTEL_COLLECT`. This variable controls how much detail is captured and defaults to `"all"`.
 


### PR DESCRIPTION
Addresses posit-dev/py-shiny#2274.

## What

Restructures the OpenTelemetry Quick Start's **Basic Configuration** around zero-code auto-instrumentation, with parallel Setup → App → Run instructions for each approach (uv is assumed as the installer throughout):

- **Zero-code (default)** tab: `uv add "shiny[otel]"`, an app with no instrumentation code, and `uv run opentelemetry-instrument shiny run app.py` (`--traces_exporter console` for local debugging, OTLP by default). Tips: set `OTEL_SERVICE_NAME` (otherwise `service.name: unknown_service`), auto-instrumentation also covers other libraries, and `shiny run --reload` works.
- **Code-based** tab: the in-code `trace.set_tracer_provider()` alternative for when you can't control the launch command, run directly with `uv run shiny run app.py`. Ends with a tip: prefer zero-code (per-environment config without app changes, per the [OTel instrumentation concepts](https://opentelemetry.io/docs/concepts/instrumentation/)), and configure OpenTelemetry in exactly one place — under `opentelemetry-instrument`, an in-code provider call logs `Overriding of current TracerProvider is not allowed` and is ignored.
- **Logfire** is a subsection of the Zero-code tab: it leads with the zero-code path (Logfire is a standard OTLP backend — export with `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, the `logfire-us`/`logfire-eu` endpoint, and a write token), followed by the `logfire` SDK setup as the code-based alternative.

## Why it works

py-shiny resolves the global tracer provider lazily at span-creation time (`shiny/otel/_core.py`), so the provider installed by `opentelemetry-instrument` is picked up with no code changes. Verified empirically: `session_start`/`reactive_update`/`session_end` spans export to the console, with and without `--reload`; the provider-override warning was also reproduced.

## Depends on

posit-dev/py-shiny#2349 (merged) — adds `opentelemetry-distro[otlp]` to the `shiny[otel]` extra, so `opentelemetry-instrument` ships with `pip install "shiny[otel]"`. Until that releases, users need an extra `pip install opentelemetry-distro opentelemetry-exporter-otlp`.

This PR targets the `rc-shiny-v1.7.0` staging branch (not `main`), so it can merge now that posit-dev/py-shiny#2349 has landed; the staging branch merges to `main` when Shiny v1.7.0 is released and the site's py-shiny pin is bumped.