### PR TITLE
chore: update GHA actions to node24, replace bobheadxi/deployments

### DIFF
--- a/.github/internal/deployment-finish/action.yml
+++ b/.github/internal/deployment-finish/action.yml
@@ -1,0 +1,35 @@
+name: Finish GitHub deployment
+description: Updates a GitHub deployment status to success or failure
+
+inputs:
+  deployment_id:
+    description: GitHub deployment ID from the start step
+    required: true
+  environment:
+    description: Deployment environment name
+    required: true
+  status:
+    description: Final job status (success, failure, cancelled)
+    required: true
+  environment_url:
+    description: URL of the deployed environment
+    required: true
+  token:
+    description: GitHub token
+    required: true
+  log_url:
+    description: Link to the Actions run log
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        gh api "repos/${{ github.repository }}/deployments/${{ inputs.deployment_id }}/statuses" \
+          --method POST \
+          -f state="${{ inputs.status }}" \
+          -f environment_url="${{ inputs.environment_url }}" \
+          -f log_url="${{ inputs.log_url }}"

--- a/.github/internal/deployment-start/action.yml
+++ b/.github/internal/deployment-start/action.yml
@@ -1,0 +1,45 @@
+name: Start GitHub deployment
+description: Creates a GitHub deployment and marks it in_progress
+
+inputs:
+  environment:
+    description: Deployment environment name
+    required: true
+  ref:
+    description: Git ref to deploy
+    required: true
+  token:
+    description: GitHub token
+    required: true
+  log_url:
+    description: Link to the Actions run log
+    required: true
+
+outputs:
+  deployment_id:
+    description: GitHub deployment ID
+    value: ${{ steps.create.outputs.deployment_id }}
+  env:
+    description: Environment name (echoed for downstream use)
+    value: ${{ inputs.environment }}
+
+runs:
+  using: composite
+  steps:
+    - id: create
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        deployment_id=$(gh api "repos/${{ github.repository }}/deployments" \
+          --method POST \
+          -f ref="${{ inputs.ref }}" \
+          -f environment="${{ inputs.environment }}" \
+          -F auto_merge=false \
+          -f "required_contexts[]=" \
+          --jq '.id')
+        gh api "repos/${{ github.repository }}/deployments/${deployment_id}/statuses" \
+          --method POST \
+          -f state="in_progress" \
+          -f log_url="${{ inputs.log_url }}"
+        echo "deployment_id=${deployment_id}" >> "$GITHUB_OUTPUT"

--- a/.github/internal/deployment-start/action.yml
+++ b/.github/internal/deployment-start/action.yml
@@ -30,16 +30,18 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        DEPLOY_REF: ${{ inputs.ref }}
+        DEPLOY_ENV: ${{ inputs.environment }}
+        DEPLOY_LOG_URL: ${{ inputs.log_url }}
       run: |
-        deployment_id=$(gh api "repos/${{ github.repository }}/deployments" \
-          --method POST \
-          -f ref="${{ inputs.ref }}" \
-          -f environment="${{ inputs.environment }}" \
-          -F auto_merge=false \
-          -f "required_contexts[]=" \
-          --jq '.id')
+        # Use --input with explicit JSON so required_contexts is a real empty
+        # array — gh api -f cannot express an empty array, which causes a 409.
+        deployment_id=$(printf '{"ref":"%s","environment":"%s","auto_merge":false,"required_contexts":[]}' \
+          "$DEPLOY_REF" "$DEPLOY_ENV" \
+          | gh api "repos/${{ github.repository }}/deployments" \
+              --method POST --input - --jq '.id')
         gh api "repos/${{ github.repository }}/deployments/${deployment_id}/statuses" \
           --method POST \
           -f state="in_progress" \
-          -f log_url="${{ inputs.log_url }}"
+          -f log_url="$DEPLOY_LOG_URL"
         echo "deployment_id=${deployment_id}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -138,7 +138,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           ALIAS: ${{ steps.deployment.outputs.env }}
         run: |
-          npm install -g netlify-cli@15.11.0
+          npm install -g netlify-cli@26.1.0
           # push main branch to production, others to preview --
           if [ "${REF_NAME}" == "main" ]; then
             netlify deploy --dir=_build/ --prod

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,9 +28,9 @@ jobs:
     env:
       SHARD_COUNT: ${{ (github.event_name == 'workflow_dispatch' && inputs.full_render) && 1 || 10 }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Restore shinylive render cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: .quarto/shinylive-cache
           key: shinylive-cache-${{ hashFiles('requirements.txt') }}-${{ github.run_id }}
@@ -50,6 +50,7 @@ jobs:
       # =====================================================
       - name: Check out submodules
         run: |
+          git config --global init.defaultBranch main
           make submodules
 
       - uses: quarto-dev/quarto-actions/setup@v2
@@ -76,7 +77,7 @@ jobs:
           python3 scripts/ci-shard.py --shard ${{ matrix.shard }} --count ${{ env.SHARD_COUNT }}
           make site QUARTO_PATH=quarto
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: site-shard-${{ matrix.shard }}
           path: _build/
@@ -87,7 +88,7 @@ jobs:
       # entries are content-addressed, so an unchanged hash means nothing new.
       - name: Save shinylive render cache
         if: always() && steps.shinylive-cache-state.outputs.hash != hashFiles('.quarto/shinylive-cache/**')
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: .quarto/shinylive-cache
           key: shinylive-cache-${{ hashFiles('requirements.txt') }}-${{ github.run_id }}-${{ matrix.shard }}
@@ -96,8 +97,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: site-shard-*
           path: _shards/
@@ -122,14 +123,13 @@ jobs:
 
       - name: Create Github "view deployment" button in PR
         if: ${{github.event_name == 'pull_request'}}
-        uses: bobheadxi/deployments@v1
+        uses: ./.github/internal/deployment-start
         id: deployment
         with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.RELEASE_NAME }}
+          environment: ${{ env.RELEASE_NAME }}
           ref: ${{ github.head_ref }}
-          logs: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          log_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Deploy to Netlify
         env:
@@ -147,13 +147,12 @@ jobs:
           fi
 
       - name: Update Github "view deployment" button in PR
-        uses: bobheadxi/deployments@v1
+        uses: ./.github/internal/deployment-finish
         if: ${{ steps.deployment.conclusion != 'failure' && github.event_name == 'pull_request'}}
         with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env: ${{ steps.deployment.outputs.env }}
-          env_url: "https://${{ steps.deployment.outputs.env }}--pyshiny.netlify.app"
-          logs: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          environment: ${{ steps.deployment.outputs.env }}
+          status: ${{ job.status }}
+          environment_url: "https://${{ steps.deployment.outputs.env }}--pyshiny.netlify.app"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          log_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary

- Bumps all `actions/*` steps from their old node20 versions to the current node24 releases: `checkout` v3→v7, `cache/restore` and `cache/save` v4→v6, `upload-artifact` v4→v7, `download-artifact` v4→v8. This eliminates the \"Node 20 is being deprecated\" deprecation warnings that appeared in every shard's log.
- Replaces `bobheadxi/deployments@v1` (stuck on node20, no node24 release) with two local composite actions in `.github/internal/` that call the GitHub Deployments REST API directly via `gh api`. This removes the last node20 action from the workflow.
- Adds `git config --global init.defaultBranch main` before `make submodules` to suppress the detached-HEAD hint git emits during submodule init.

## Verification

Open a PR against this repo after merging. The deploy job should show a \"View deployment\" button as before, and the Actions log should no longer contain any \"Node 20 is being deprecated\" warnings.