### PR TITLE
feat: Add Task Button and Bookmark Button components

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -143,6 +143,7 @@ website:
           contents:
             - components/inputs/action-button/index.qmd
             - components/inputs/action-link/index.qmd
+            - components/inputs/bookmark-button/index.qmd
             - components/inputs/checkbox/index.qmd
             - components/inputs/checkbox-group/index.qmd
             - components/inputs/dark-mode/index.qmd
@@ -159,6 +160,7 @@ website:
             - components/inputs/slider/index.qmd
             - components/inputs/slider-range/index.qmd
             - components/inputs/switch/index.qmd
+            - components/inputs/task-button/index.qmd
             - components/inputs/text-area/index.qmd
             - components/inputs/text-box/index.qmd
             - components/inputs/toolbar-button/index.qmd

--- a/components/inputs/bookmark-button/app-core.py
+++ b/components/inputs/bookmark-button/app-core.py
@@ -1,0 +1,19 @@
+from starlette.requests import Request
+
+from shiny import App, ui
+
+
+def app_ui(request: Request):
+    return ui.page_fluid(
+        ui.input_radio_buttons("letter", "Choose a letter", choices=["A", "B", "C"]),
+        ui.input_bookmark_button(),  # <<
+    )
+
+
+def server(input, output, session):
+    @session.bookmark.on_bookmarked
+    async def _(url: str):
+        await session.bookmark.update_query_string(url)
+
+
+app = App(app_ui, server, bookmark_store="url")

--- a/components/inputs/bookmark-button/app-detail-preview.py
+++ b/components/inputs/bookmark-button/app-detail-preview.py
@@ -1,0 +1,28 @@
+## file: app.py
+from starlette.requests import Request
+
+from shiny import App, ui
+
+
+def app_ui(request: Request):
+    return ui.page_fluid(
+        ui.row(
+            ui.column(
+                12,
+                ui.input_radio_buttons(
+                    "letter", "Choose a letter", choices=["A", "B", "C"]
+                ),
+                ui.input_bookmark_button(),
+            ),
+            {"class": "vh-100 justify-content-center align-items-center px-5"},
+        ).add_class("text-center")
+    )
+
+
+def server(input, output, session):
+    @session.bookmark.on_bookmarked
+    async def _(url: str):
+        await session.bookmark.update_query_string(url)
+
+
+app = App(app_ui, server, bookmark_store="url")

--- a/components/inputs/bookmark-button/app-express.py
+++ b/components/inputs/bookmark-button/app-express.py
@@ -1,0 +1,11 @@
+from shiny.express import app_opts, session, ui
+
+app_opts(bookmark_store="url")
+
+ui.input_radio_buttons("letter", "Choose a letter", choices=["A", "B", "C"])
+ui.input_bookmark_button()  # <<
+
+
+@session.bookmark.on_bookmarked
+async def _(url: str):
+    await session.bookmark.update_query_string(url)

--- a/components/inputs/bookmark-button/app-preview.py
+++ b/components/inputs/bookmark-button/app-preview.py
@@ -1,0 +1,13 @@
+from shiny import App, ui
+
+app_ui = ui.page_fluid(
+    ui.input_bookmark_button(),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+
+def server(input, output, session):
+    pass
+
+
+app = App(app_ui, server)

--- a/components/inputs/bookmark-button/index.qmd
+++ b/components/inputs/bookmark-button/index.qmd
@@ -1,0 +1,76 @@
+---
+title: Bookmark Button
+sidebar: components
+appPreview:
+  file: components/inputs/bookmark-button/app-preview.py
+  static: true
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/inputs/bookmark-button/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 200
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhWQZ0AfVLoKrIqxGtO5IgFdOAHQhH5SlawAUAI1KkA1jCgM7C1hWlwAvAbC6GAGx8ASiMjfSxudF0KBQYoABNtBSto9whLH384CioGHyIfAGF2Ww05ZCycuDzCZGISzmIRT2AfAEF85B8AIU6inwBdEIhwyOjk2wcnFxSc8gsg5GQAYmQAHjXQ4wgAAQ1RbQgsG3tHZyxyCdPpuHiTVlwIYmR4uDpkBQs-fxQ3BiDEEYlksoAB3KCcWT7LTkY6TM52LC6dDxKBUBQAR101VwrgoDG4AHMvgFhrUwBRcOgECgKQIKGAAL4DIA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwqgYBs4KqsGcAI4BXOO1bIAljHSkGFZACVhY9gB0ImxszYALKRFzTZ8xQEFMREVM12IAEzh1kGdAH0bACkGjxFFBU-dgBKRE1kSORBChEGCGQbHCgAczh3Oi4bBy8IqPykw3QRCncGKAcpUncAIxKKclZcsB4+OAZ1QmROgGE9UlJWOFdkVqoOruJ+qWJxAF5gTvNOok6AIRXusB7OgF0Qgjz8yMKIYtKagYBrGE4r2vryLwPIgGJkAB4Po+QQ+00nC4hgwAG7tLxFEpEUglc5EIasVhVCBhH4AAQRSPIWEupBudyw5Fq11uDCucAcPygrFwEGIyEByHcXjiXBQ7AYqISx0iUAA7lApIpMcicSSCSJ0A4oFR3H4GLh3BzDCkWdw-lpNW5kHNkJZ0F43J4pPD2mCGERcfiyUqGoI5p1WZ0NV0wBRcOgECg3XAAB4UMAAX12QA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.input_bookmark_button
+    href: https://shiny.posit.co/py/api/core/ui.input_bookmark_button.html
+    signature: ui.input_bookmark_button(label='Bookmark...', *, icon=MISSING, width=None,
+      disabled=False, id='._bookmark_', title="Bookmark this application's state and
+      get a URL for sharing.", **kwargs)
+  - title: bookmark.Bookmark
+    href: https://shiny.posit.co/py/api/core/bookmark.Bookmark.html
+    signature: session.bookmark
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A bookmark button lets users save and share the current state of an app as a URL. It is an [action button](../action-button/index.qmd) with a default label and link icon meant specifically for triggering `session.bookmark()`.
+
+Follow these steps to add a bookmark button to your app:
+
+  1. Enable bookmarking for your app by passing `bookmark_store="url"` (or `"server"`) to `App()` in Core, or by calling `app_opts(bookmark_store="url")` in Express.
+
+  2. Add `ui.input_bookmark_button()` to the UI of your app. In Core, the UI function must accept a `request` argument (e.g. `def app_ui(request): ...`) so that each user's bookmarked state can be restored independently.
+
+  3. Optionally customize the `label`, `icon`, `width`, or `title` (tooltip) parameters of `ui.input_bookmark_button()`.
+
+Clicking the button calls `session.bookmark()`, which saves the current input values and, for `bookmark_store="url"`, updates the browser's URL with a query string that encodes them. Reloading that URL restores the saved inputs.
+
+To update the browser's address bar in place (instead of navigating to a new URL), register a `session.bookmark.on_bookmarked()` callback that calls `session.bookmark.update_query_string()`:
+
+```python
+@session.bookmark.on_bookmarked
+async def _(url: str):
+    await session.bookmark.update_query_string(url)
+```
+
+### Multiple bookmark buttons
+
+By default, Shiny listens for the bookmark button's default `id` and calls `session.bookmark()` automatically on click. If you use more than one bookmark button, or use one inside a [module](/docs/modules.qmd), supply a custom `id` for each button, exclude that `id` from bookmarking, and trigger the bookmark yourself:
+
+```python
+session.bookmark.exclude.append("custom_id")
+
+@reactive.effect
+@reactive.event(input.custom_id)
+async def _():
+    await session.bookmark()
+```
+
+See also: [Action Button](../action-button/index.qmd)

--- a/components/inputs/task-button/app-core.py
+++ b/components/inputs/task-button/app-core.py
@@ -1,0 +1,19 @@
+import time
+
+from shiny import App, reactive, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_task_button("task_button", "Run task"),  # <<
+    ui.output_text("result"),
+)
+
+
+def server(input, output, session):
+    @render.text
+    @reactive.event(input.task_button)
+    def result():
+        time.sleep(2)
+        return f"Task completed {input.task_button()} time(s)"
+
+
+app = App(app_ui, server)

--- a/components/inputs/task-button/app-detail-preview.py
+++ b/components/inputs/task-button/app-detail-preview.py
@@ -1,0 +1,29 @@
+## file: app.py
+import time
+
+from shiny import App, reactive, render, ui
+
+app_ui = ui.page_fluid(
+    ui.row(
+        ui.column(6, ui.input_task_button("task_button", "Run Task")),
+        ui.column(6, ui.output_text("counter").add_class("display-5 mb-0")),
+        {"class": "vh-100 justify-content-center align-items-center px-5"},
+    ).add_class("text-center")
+)
+
+
+def server(input, output, session):
+    count = reactive.value(0)
+
+    @reactive.effect
+    @reactive.event(input.task_button)
+    def _():
+        time.sleep(1)
+        count.set(count() + 1)
+
+    @render.text
+    def counter():
+        return f"{count()}"
+
+
+app = App(app_ui, server)

--- a/components/inputs/task-button/app-express.py
+++ b/components/inputs/task-button/app-express.py
@@ -1,0 +1,13 @@
+import time
+
+from shiny import reactive, render
+from shiny.express import input, ui
+
+ui.input_task_button("task_button", "Run task")  # <<
+
+
+@render.text
+@reactive.event(input.task_button)
+def result():
+    time.sleep(2)
+    return f"Task completed {input.task_button()} time(s)"

--- a/components/inputs/task-button/app-preview.py
+++ b/components/inputs/task-button/app-preview.py
@@ -1,0 +1,18 @@
+from shiny import App, reactive, render, ui
+
+app_ui = ui.page_fluid(
+    ui.input_task_button("task_button", "Run Task"),
+    ui.output_text("result"),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+
+def server(input, output, session):
+    @output
+    @render.text
+    @reactive.event(input.task_button)
+    def result():
+        return ""
+
+
+app = App(app_ui, server)

--- a/components/inputs/task-button/index.qmd
+++ b/components/inputs/task-button/index.qmd
@@ -1,0 +1,77 @@
+---
+title: Task Button
+sidebar: components
+appPreview:
+  file: components/inputs/task-button/app-preview.py
+  static: true
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/inputs/task-button/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 200
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQEsZ1SAnC5ChuAHQh4DNmpGMgDOACzoRcyBk1bJmcKMQ4A3OEUUQAJnGb9Bw8ZNxY4AD3SKRImYxZtJ6AK4Uizujx4esT1wH0KKBEAa38AI1cKcgAKLjAg0Iio8niieIAlZwh2YJD4gEpkZABiZAAecq9eCAABLV1mLCpzCh56pRU6dTN1Shi-Cma85IpoiAKeXT4FOBFnABsKGILEHmLijngsEQW4OHQYgCZJnI3FCmdmHL54gBU85DJGPaptZBBB4aTIsdiCgC+7E4MREkzAPEIqAouHQCBQCQsFDAAIAukA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQEsZ1SAnC5ChuAHQh4DNmpGMgDOACzoRcyBk1bIAgpiLM4UYhwBucFdQAmcZkQCudHjwzoA+qeQBeZKZxQA5nCt8ANqb0AKHsiBjnRYkujGFFYUUCIA1lYARhEU5P5g0XGJyeRchMi5AErGEOwxsbkAlETIAMTIADz1AUFOpBHhkVQAHhRpqiLGnhSVBDwV5rwQBnyihtrMvmERRG0UHUQicCIidOQViM2BAAKqU4ZY3cMlQSdqGnTaWHDalIsQHRdlWRQpEOPXgWmyH6g16+0OQUCHHgWBEnjgcHQvgATP9IZDVBRjMwSnxcgAVMrIMiMeFUPTIEBLCifTJJH6pCoAX3YnF8InGYAmFkw9kUmF8lhsdA2c0M-zy6Vw6AQKHScB6YCZAF0gA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.input_task_button
+    href: https://shiny.posit.co/py/api/core/ui.input_task_button.html
+    signature: ui.input_task_button(id, label, *args, icon=None, label_busy='Processing...',
+      icon_busy=MISSING, width=None, type='primary', auto_reset=True, **kwargs)
+  - title: ui.update_task_button
+    href: https://shiny.posit.co/py/api/core/ui.update_task_button.html
+    signature: ui.update_task_button(id, *, state, session=None)
+  - title: reactive.extended_task
+    href: https://shiny.posit.co/py/api/core/reactive.extended_task.html
+    signature: reactive.extended_task(f)
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A task button is similar to an [action button](../action-button/index.qmd), except that it prevents the user from clicking again while its associated operation is already in progress. On click, it automatically displays a busy message and disables itself, then resets back to its normal appearance once the server has finished handling the click.
+
+Follow these steps to add a task button to your app:
+
+  1. Add `ui.input_task_button()` to the UI of your app to create a task button. Where you call this function will determine where the button will appear within the app's layout.
+
+  2. Specify the `id` and `label` parameters of `ui.input_task_button()` to define the button's identifier and its label when ready to be clicked.
+
+  3. Optionally, set `label_busy` to customize the message shown while the button is busy (defaults to `"Processing..."`).
+
+The value of a task button is accessible as a reactive value within the `server()` function. To access the value of a task button:
+
+  1. Use `input.<task_button_id>()` (e.g., `input.task_button()`) to access the value of the task button. The server value of a task button is an integer representing the number of clicks.
+
+### Long-running tasks
+
+For operations that take a while to complete, pair `ui.input_task_button()` with [`reactive.extended_task()`](https://shiny.posit.co/py/api/core/reactive.extended_task.html) so the rest of the app stays responsive while the task runs in the background. Bind the task to the button with `ui.bind_task_button()` so the button automatically shows its busy state for as long as the task is running:
+
+```python
+@ui.bind_task_button(button_id="task_button")
+@reactive.extended_task
+async def slow_compute(x: int, y: int) -> int:
+    await asyncio.sleep(3)
+    return x + y
+
+
+@reactive.effect
+@reactive.event(input.task_button)
+def handle_click():
+    slow_compute(input.x(), input.y())
+```
+
+See also: [Action Button](../action-button/index.qmd)


### PR DESCRIPTION
  ## Summary
  - Add a "Task Button" component page demonstrating `ui.input_task_button()`, including its busy/processing state, auto-reset behavior, and pairing with `reactive.extended_task` /
  `ui.bind_task_button` for long-running operations
  - Add a "Bookmark Button" component page demonstrating `ui.input_bookmark_button()`, including `bookmark_store="url"`, the `session.bookmark.on_bookmarked` callback, and handling multiple
  bookmark buttons/modules
  - Wire both into the Inputs sidebar in `_quarto.yml`, with generated shinylive links and static previews
  
fixes https://github.com/posit-dev/py-shiny-site/issues/259 partially