### PR TITLE
docs: Add Agent Skills installation page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -247,6 +247,7 @@ website:
         - get-started/index.qmd
         - get-started/what-is-shiny.qmd
         - get-started/install.qmd
+        - get-started/agent-skills.qmd
         - get-started/create-run.qmd
         - get-started/debug.qmd
         - section: "Deploy"

--- a/get-started/agent-skills.qmd
+++ b/get-started/agent-skills.qmd
@@ -1,0 +1,74 @@
+---
+title: Agent Skills
+
+editor:
+  markdown:
+    wrap: sentence
+---
+
+If you use a coding agent such as [Claude Code](https://www.claude.com/product/claude-code) or [Cursor](https://cursor.com/) to help you build Shiny apps, you can teach it how to use Shiny for Python's public APIs by installing the [Agent Skill](https://agentskills.io) that ships with the `shiny` package.
+
+## What is the bundled skill?
+
+An [Agent Skill](https://agentskills.io) is a set of reference docs, written for coding agents, that teaches them how to work with a particular library.
+The `shiny` package ships a single skill, `shiny-for-python`, that teaches agents how to build, style, test, and debug Shiny for Python apps using shiny's public APIs.
+
+The skill lives inside the installed package (under `shiny/.agents/skills/`) and follows the [Agent Skills](https://agentskills.io) specification and the [library-skills](https://library-skills.io) convention of shipping skills with the library they document.
+Its `SKILL.md` is a routing index: the agent reads it first, then follows links into per-topic reference files as needed.
+Because the skill ships with the package, it always matches the version of `shiny` you have installed, and there is nothing extra to download.
+
+## Install the skill into your project
+
+Once `shiny` is a dependency of your project, use [`library-skills`](https://library-skills.io) to make the bundled skill available to your agent.
+Run these commands from your own project directory (where `shiny` is installed) — `library-skills` finds the skill in your installed `shiny` package, so this is not tied to the py-shiny source repository.
+
+::: {.panel-tabset .panel-pills}
+
+#### Claude Code
+
+Install the skill into your project's `.claude/skills` directory:
+
+```bash
+uvx library-skills --claude
+```
+
+#### Other agents
+
+Install the skill into the standard `.agents/skills` location that most agents read:
+
+```bash
+uvx library-skills
+```
+
+On Windows, add the `--copy` flag:
+
+```bash
+uvx library-skills --copy
+```
+
+:::
+
+By default, `library-skills` symlinks the packaged skill into your project rather than copying it.
+This means the skill stays in sync automatically when you upgrade `shiny` — there is no separate step to re-install it after an upgrade.
+
+::: {.callout-tip}
+See `uvx library-skills --help` for the full list of options.
+:::
+
+## Inspect the skill without installing it
+
+The `shiny` command line interface can show you the bundled skill directly, which is handy if you want to read it before installing or point another tool at it.
+
+List the bundled skills with their names and descriptions:
+
+```bash
+shiny skills list
+```
+
+Print the directory that contains a skill so you can open its `SKILL.md` and reference files:
+
+```bash
+shiny skills path shiny-for-python
+```
+
+See `shiny skills --help` for more details.

--- a/get-started/agent-skills.qmd
+++ b/get-started/agent-skills.qmd
@@ -65,10 +65,4 @@ List the bundled skills with their names and descriptions:
 shiny skills list
 ```
 
-Print the directory that contains a skill so you can open its `SKILL.md` and reference files:
-
-```bash
-shiny skills path shiny-for-python
-```
-
 See `shiny skills --help` for more details.

--- a/get-started/install.qmd
+++ b/get-started/install.qmd
@@ -152,6 +152,13 @@ uv pip install shiny
 
 :::
 
+::: {.callout-tip}
+## Recommended: install Shiny's Agent Skills
+
+If you use a coding agent such as Claude Code or Cursor, we also recommend installing Shiny's bundled [Agent Skills](agent-skills.qmd).
+They teach your agent how to build, style, test, and debug Shiny for Python apps using shiny's public APIs.
+:::
+
 ## Positron {#positron}
 
 We recommend using

--- a/get-started/install.qmd
+++ b/get-started/install.qmd
@@ -152,12 +152,10 @@ uv pip install shiny
 
 :::
 
-::: {.callout-tip}
-## Recommended: install Shiny's Agent Skills
+### Agent Skills
 
 If you use a coding agent such as Claude Code or Cursor, we also recommend installing Shiny's bundled [Agent Skills](agent-skills.qmd).
 They teach your agent how to build, style, test, and debug Shiny for Python apps using shiny's public APIs.
-:::
 
 ## Positron {#positron}
 


### PR DESCRIPTION
## Summary

Adds a prose documentation page explaining how a Shiny for Python user makes the bundled `shiny-for-python` Agent Skill available to their coding agent (Claude Code, Cursor, etc.).

This is the docs-site follow-up to py-shiny #2367 (merged), which added the equivalent, terser content to the py-shiny README. The prose docs live in this separate repo, so the content is expanded here into a standalone getting-started page.

## What's in the page

- Explains that the `shiny` package ships a single bundled Agent Skill, `shiny-for-python` (under `shiny/.agents/skills/`), following the [agentskills.io](https://agentskills.io) spec and the [library-skills.io](https://library-skills.io) convention. Its `SKILL.md` is a routing index into per-topic reference files.
- Install instructions via `library-skills`, using `uv`/`uvx` (not `pip`):
  - Claude Code (into `.claude/skills`): `uvx library-skills --claude`
  - Standard `.agents/skills` location: `uvx library-skills` (with `--copy` note for Windows)
- Notes that `library-skills` symlinks the packaged skill so it stays in sync when `shiny` is upgraded, and that it runs from the user's own project directory.
- Documents inspecting the skill without installing via the `shiny skills` CLI: `shiny skills list` and `shiny skills path shiny-for-python`. (There is intentionally no `get` subcommand.)

## Placement

- New file: `get-started/agent-skills.qmd`
- Registered in the `get-started` sidebar in `_quarto.yml`, immediately after `install.qmd` (install-adjacent, since the page is fundamentally about installing the skill into a project).
- If a reviewer prefers a different home (e.g. under Concepts > Miscellaneous), the page moves easily — flagging the placement choice for review.

## Validity check

`quarto render` against the full project config fails locally due to a Quarto version mismatch (the installed Quarto 1.8.25 rejects the site's newer `llms-txt`/`plausible-analytics` `_quarto.yml` keys) — this is unrelated to the new page. As a substitute, the page was rendered standalone (`quarto render agent-skills.qmd`) successfully, confirming the frontmatter and markdown are valid. A full site build was intentionally not run.

Ref: posit-dev/py-shiny#2367