### PR TITLE
ci: verify shinylive links are up to date

### DIFF
--- a/.claude/skills/writing-component-pages/SKILL.md
+++ b/.claude/skills/writing-component-pages/SKILL.md
@@ -148,6 +148,24 @@ Run `make components-shinylive-links` (script: `components/update-shinylive-link
 It encodes each app's source into the `shinylive:` value in place. You only need a
 `shinylive:` **key** present (a placeholder value is fine); the script overwrites it.
 
+**Always re-run `make components-shinylive-links` after editing, adding, or removing
+any `app-*.py` file (or its `resources:`).** The `shinylive:` values are an encoding of
+the app source, so any change to the source makes the committed link stale. This is not
+optional: the `check-shinylive-links` GitHub Actions workflow regenerates the links on
+every PR and **fails the build if the committed links differ**. Regenerate and commit the
+updated `index.qmd` files as part of the same change — do not leave it for later.
+
+To rebuild just the page(s) you touched (faster than rewriting all of them), pass
+`FILES=` — it accepts component dirs, `index.qmd` paths, or any file inside a component
+dir (e.g. the `app-*.py` you just edited), which it resolves to the owning `index.qmd`:
+
+```bash
+make components-shinylive-links FILES="components/inputs/<name>/"
+make components-shinylive-links FILES="components/inputs/<name>/app-core.py components/inputs/<name>/app-express.py"
+```
+
+With no `FILES`, it rewrites every component page (what CI does).
+
 - **Multi-file apps:** if an app needs extra files, split with `## file: app.py`
   markers inside the `.py`, and list companion assets under a `resources:` key in the
   front-matter entry. The link checker warns `Multiple files in app` when a bundle has

--- a/.github/workflows/check-shinylive-links.yml
+++ b/.github/workflows/check-shinylive-links.yml
@@ -1,0 +1,60 @@
+name: Check shinylive links
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: check-shinylive-links-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-shinylive-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Single source of truth: the Makefile's `PYTHON_VERSION ?= ...` controls
+      # the venv Python, so read it here rather than hardcoding a version.
+      - name: Read Python version from Makefile
+        id: python-version
+        run: |
+          version="$(sed -n 's/^PYTHON_VERSION[[:space:]]*?=[[:space:]]*//p' Makefile | head -n1)"
+          if [ -z "$version" ]; then
+            echo "::error::Could not read PYTHON_VERSION from Makefile"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ steps.python-version.outputs.version }}
+
+      # The link generator's `shinylive:` values must be encoded with the same
+      # shinylive version the site build uses, or this check produces false
+      # failures. `make deps` (pulled in by `components-shinylive-links`)
+      # installs py-shiny's docs extras, which pin shinylive from git -- exactly
+      # what the site build does -- so check out the submodule it needs.
+      - name: Check out submodules
+        run: |
+          git config --global init.defaultBranch main
+          make submodules
+
+      # Regenerate the shinylive links embedded in the component index.qmd
+      # files. The Makefile self-manages its uv venv.
+      - name: Regenerate shinylive links
+        run: make components-shinylive-links
+
+      # If regenerating changed any tracked file, the committed links are stale.
+      - name: Verify shinylive links are up to date
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Shinylive links are out of date. Run 'make components-shinylive-links' and commit the result."
+            echo "--- Offending diff ---"
+            git diff
+            exit 1
+          fi
+          echo "Shinylive links are up to date."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,11 @@ make deps
 # Generate API docs (outputs to api/)
 make quartodoc
 
-# Update component Shinylive links
+# Update component Shinylive links (all pages)
 make components-shinylive-links
+# ...or just the pages you touched (dirs, index.qmd, or any file inside a
+# component dir such as an edited app-*.py — resolved to the owning index.qmd)
+make components-shinylive-links FILES="components/inputs/action-button/app-core.py"
 
 # Generate static component previews
 make components-static
@@ -246,6 +249,10 @@ All code examples use Shinylive to run Python in the browser via WebAssembly. Th
 - **Platform:** Hosted on Netlify
 - **Output directory:** `_build/` (configured in _quarto.yml)
 
+### Other CI checks
+
+- **`check-shinylive-links`** (`.github/workflows/check-shinylive-links.yml`) — on every PR, regenerates the component Shinylive links (`make components-shinylive-links`) and **fails if the committed links differ**. This catches an edited `app-*.py` whose `shinylive:` link in `index.qmd` wasn't regenerated. It installs the py-shiny submodule + full `deps` so the shinylive version matches the site build, and reads `PYTHON_VERSION` from the Makefile. Fix a failure by running `make components-shinylive-links` and committing the updated `index.qmd` files.
+
 ## Working with Components
 
 Component pages follow a consistent structure:
@@ -258,12 +265,17 @@ Component pages follow a consistent structure:
 To update component examples:
 
 ```bash
-# Regenerate Shinylive links
+# Regenerate Shinylive links (add FILES="..." to limit to specific pages)
 make components-shinylive-links
 
 # Regenerate static preview images
 make components-static
 ```
+
+**Always regenerate the Shinylive links after editing any `app-*.py` file** and
+commit the updated `index.qmd`. The `shinylive:` values encode the app source, so
+a stale link ships the wrong code — and the `check-shinylive-links` CI workflow
+fails the PR when committed links are out of date.
 
 ## Working with API Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,10 @@ components-static: $(PYBIN) deps
 	rm -rf components/static
 	. $(PYBIN)/activate && python components/make-static-previews.py
 
+## Update shinylive links; pass FILES="dir-or-file ..." to limit to those pages
 .PHONY: components-shinylive-links
 components-shinylive-links: $(PYBIN) deps
-	. $(PYBIN)/activate && python components/update-shinylive-links.py
+	. $(PYBIN)/activate && python components/update-shinylive-links.py $(FILES)
 
 ## Remove Quarto website build files
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ re-port or retire it).
 - Commits to `main` deploy to production the same way.
 - Escape hatch: run the workflow manually (`workflow_dispatch`) with
   `full_render = true` to build in a single unsharded job.
+- A separate **`check-shinylive-links`** workflow runs on every PR: it
+  regenerates the component Shinylive links and fails if the committed links
+  are out of date. So after editing any `app-*.py`, run
+  `make components-shinylive-links` (optionally scoped with `FILES="..."`) and
+  commit the updated `index.qmd`.
 
 ## Site quality checks
 

--- a/components/inputs/action-button/app-core.py
+++ b/components/inputs/action-button/app-core.py
@@ -1,5 +1,6 @@
 from shiny import App, reactive, render, ui
 
+# Demo edit to exercise the check-shinylive-links workflow (stale link).
 app_ui = ui.page_fluid(
     ui.input_action_button("action_button", "Action"),  # <<
     ui.output_text("counter"),

--- a/components/inputs/action-button/app-core.py
+++ b/components/inputs/action-button/app-core.py
@@ -1,6 +1,5 @@
 from shiny import App, reactive, render, ui
 
-# Demo edit to exercise the check-shinylive-links workflow (stale link).
 app_ui = ui.page_fluid(
     ui.input_action_button("action_button", "Action"),  # <<
     ui.output_text("counter"),

--- a/components/update-shinylive-links.py
+++ b/components/update-shinylive-links.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 import shinylive
 from _qmd import get_qmd_split, write_qmd
@@ -161,7 +162,46 @@ def rewrite_shinylive_links_all(index_qmds):
     return index_qmds
 
 
+def resolve_index_qmds(paths):
+    """
+    Map arbitrary file/dir paths to the component ``index.qmd`` they belong to.
+
+    Accepts a component directory, an ``index.qmd``, or any file inside a
+    component directory (e.g. an edited ``app-core.py``) and resolves each to
+    the owning ``index.qmd``. Paths without a real ``index.qmd`` are skipped
+    with a warning. Duplicates are collapsed, order preserved.
+    """
+    index_qmds = []
+    seen = set()
+
+    for path in paths:
+        path = os.path.normpath(path)
+        if os.path.isdir(path):
+            qmd = os.path.join(path, "index.qmd")
+        elif os.path.basename(path) == "index.qmd":
+            qmd = path
+        else:
+            qmd = os.path.join(os.path.dirname(path), "index.qmd")
+
+        if not os.path.isfile(qmd):
+            lg.warning(f"Skipping {path}: no component index.qmd found at {qmd}")
+            continue
+
+        if qmd not in seen:
+            seen.add(qmd)
+            index_qmds.append(qmd)
+
+    return index_qmds
+
+
 if __name__ == "__main__":
-    dirs = ["inputs", "outputs", "display-messages", "layout"]
-    index_qmds = find_index_qmds([os.path.join("components", d) for d in dirs])
+    # With no args, rewrite links for every component page. Given one or more
+    # path args (component dirs, index.qmd files, or any file inside a
+    # component dir such as an edited app-*.py), rewrite only those pages.
+    if len(sys.argv) > 1:
+        index_qmds = resolve_index_qmds(sys.argv[1:])
+    else:
+        dirs = ["inputs", "outputs", "display-messages", "layout"]
+        index_qmds = find_index_qmds([os.path.join("components", d) for d in dirs])
+
     rewrite_shinylive_links_all(index_qmds)


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that regenerates the component shinylive links on every PR and **fails if the committed links are stale**, so an edited \`app-*.py\` can't ship with an out-of-date \`shinylive:\` encoding.

- **New workflow** \`.github/workflows/check-shinylive-links.yml\` — runs \`make components-shinylive-links\` and fails on any resulting \`git diff\`. Uses the same submodule + full \`make deps\` install as the site build (so the shinylive version matches) and reads \`PYTHON_VERSION\` from the Makefile.
- **\`update-shinylive-links.py\`** now accepts path args (component dirs, \`index.qmd\`, or any file inside a component dir) to rebuild only those pages; exposed via \`make components-shinylive-links FILES="..."\`.
- **\`writing-component-pages\` skill** — require regenerating links after editing app files (now CI-enforced) and document the \`FILES=\` form.

## Note

This PR currently contains a **deliberately stale** demo commit (edited \`app-core.py\` without regenerating its link) to prove the new check fails. A follow-up commit reverts it so the check goes green.