### PR TITLE
fix: point install-quarto at renamed site.yml workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the **Shiny for Python documentation website** - the official documentation, API reference, component gallery, and template showcase for the Shiny for Python framework. Built with Quarto, it combines hand-written conceptual documentation with auto-generated API reference docs extracted from the main py-shiny repository.
 
+## Commits and Pull Requests
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) for **both commit messages and PR titles**. Format: `<type>: <description>` (or `<type>(<scope>): <description>`).
+
+Common types in this repo: `feat`, `fix`, `docs`, `ci`, `test`, `refactor`, `chore`, `build`. Examples:
+
+- `docs: add Accordion layout component page`
+- `ci: verify shinylive links are up to date`
+- `fix: point install-quarto at renamed site.yml workflow`
+
 ## Development Commands
 
 ### Initial Setup

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ install-quarto:
 		qvm install v${QUARTO_VERSION}; \
 		echo "🔹 Updating .vscode/settings.json"; \
 		awk -v path="${QUARTO_PATH}" '/"quarto.path":/ {gsub(/"quarto.path": ".*"/, "\"quarto.path\": \"" path "\"")} 1' .vscode/settings.json > .vscode/settings.json.tmp && mv .vscode/settings.json.tmp .vscode/settings.json; \
-		echo "🔹 Updating .github/workflows/deploy-docs.yml"; \
-		awk -v ver="${QUARTO_VERSION}" '/QUARTO_VERSION:/ {gsub(/QUARTO_VERSION: .*/, "QUARTO_VERSION: " ver)} 1' .github/workflows/deploy-docs.yml > .github/workflows/deploy-docs.yml.tmp && mv .github/workflows/deploy-docs.yml.tmp .github/workflows/deploy-docs.yml; \
+		echo "🔹 Updating .github/workflows/site.yml"; \
+		awk -v ver="${QUARTO_VERSION}" '/QUARTO_VERSION:/ {gsub(/QUARTO_VERSION: .*/, "QUARTO_VERSION: " ver)} 1' .github/workflows/site.yml > .github/workflows/site.yml.tmp && mv .github/workflows/site.yml.tmp .github/workflows/site.yml; \
 	fi
 
 $(QUARTO_PATH): install-quarto


### PR DESCRIPTION
## Problem

Fresh Conductor workspaces run `make ai-setup` as their setup script (`.conductor/settings.toml`). This failed during `install-quarto` with:

```
awk: can't open file .github/workflows/deploy-docs.yml
make[1]: *** [install-quarto] Error 2
```

The `install-quarto` target auto-syncs the pinned Quarto version into two files. One of them, `.github/workflows/deploy-docs.yml`, was **renamed to `site.yml`** in #398 (the sharded-CI refactor: `.github/workflows/{deploy-docs.yml => site.yml}`), but the Makefile reference was never updated — so every fresh workspace failed setup.

## Fix

- Point the version-sync `awk` at `.github/workflows/site.yml`.
- Document Conventional Commits (for both commit messages and PR titles) in `CLAUDE.md`.

## Verification

`make install-quarto` now completes cleanly, and the working tree shows only the intended edits.