### PR TITLE
fix: modernize chat + verbatim-text examples off unavailable APIs

### DIFF
--- a/components/display-messages/chat/app-preview.py
+++ b/components/display-messages/chat/app-preview.py
@@ -17,13 +17,10 @@ welcome = ui.markdown(
 )
 
 # Create a chat instance
-chat = ui.Chat(
-    id="chat",
-    messages=[welcome],
-)
+chat = ui.Chat(id="chat")
 
-# Display it
-chat.ui()
+# Display it, with a welcome message
+chat.ui(messages=[welcome])
 
 
 # Define a callback to run when the user submits a message

--- a/components/outputs/verbatim-text/app-variation-placeholder-rectangle-when-string-is-empty-express.py
+++ b/components/outputs/verbatim-text/app-variation-placeholder-rectangle-when-string-is-empty-express.py
@@ -1,10 +1,8 @@
 from shiny.express import input, render, ui
 
 ui.input_text("Text", "Enter Text", "")
-ui.output_text_verbatim("text", placeholder=True)  # <<
 
-with ui.hold():  # <<
 
-    @render.text  # <<
-    def text():
-        return input.Text()
+@render.code(placeholder=True)  # <<
+def text():
+    return input.Text()

--- a/components/outputs/verbatim-text/app-variation-placeholder-rectangle-when-string-is-empty-express.py
+++ b/components/outputs/verbatim-text/app-variation-placeholder-rectangle-when-string-is-empty-express.py
@@ -1,8 +1,11 @@
+from shiny import ui as core_ui
 from shiny.express import input, render, ui
 
 ui.input_text("Text", "Enter Text", "")
+core_ui.output_text_verbatim("text", placeholder=True)  # <<
 
+with ui.hold():  # <<
 
-@render.code(placeholder=True)  # <<
-def text():
-    return input.Text()
+    @render.text  # <<
+    def text():
+        return input.Text()

--- a/components/outputs/verbatim-text/index.qmd
+++ b/components/outputs/verbatim-text/index.qmd
@@ -42,7 +42,7 @@ listing:
       file: app-variation-placeholder-rectangle-when-string-is-empty-core.py
     - title: Express
       file: app-variation-placeholder-rectangle-when-string-is-empty-express.py
-      shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhXER0AVwpFhEACZwGRBZwA6EfTqzdFFAPpV+FABS6wAFQEU7ROwFFKm5I6svkduwBKfRCIAAFVDQYsMg1rdAAbKGI4dlIEqIBeewYFOEDkZABiZAAeUv0NOmRLG0DEfULC4QoFBgg5UywfOv1CVApcdAQUMFqwAF8AXSA
+      shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAV07IorZGQZwA+uIA6ERszZceWOAA90c1tP6DhfCOlEUiciABM4DIsogrxWbhYryqOigAolMAAVXQpAokCAUUoHZBDfcORAwIBKFVkFN1JLT29Q+QA3BwAjKAp+ALAfMMJkdAAbKGI4dlJ6+wYAXiCGUTgU5GQAYmQAHlGVFQB3Tgp2MU4sVva-FJRhsYmXCEHBgAEbDqxqwZHxlV3kezpkatXEC8vduQpRBh2PSyx4-zSIWqquHQCBQVVCYAAvgBdIA
     - title: Core
       file: app-variation-placeholder-rectangle-when-string-is-empty-core.py
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAQUxEG1ACZwGRAK6cAOhFUZ0AfSXIAvMiU4oAczia6AGyXSAFKuQODnLN3QKKmqgA8KdsABU4H2VCZBCAUUo5ZEDg0JCQgEoCe0dDUnc3D28PADc5ACMoCn4-HJCidAsoYjh2UgtZBl1-BgU4ZIcAYmQAHl7VRNVhiFk6Njl8hhtXdyIMiiyiVjhWVk5yRMRUhwABKVG5LBzuvoGIR2Qx5BybLZ3L5CkKBQYL2YosWN8htT+NPRiTA2DTaTjLSZyX6hMAUXDoBAoWFBChgAC+AF0gA

--- a/components/outputs/verbatim-text/index.qmd
+++ b/components/outputs/verbatim-text/index.qmd
@@ -42,7 +42,7 @@ listing:
       file: app-variation-placeholder-rectangle-when-string-is-empty-core.py
     - title: Express
       file: app-variation-placeholder-rectangle-when-string-is-empty-express.py
-      shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhXER0AVwpFhEACZwGRBZwA6EfTqzdFFAPpV+FABS6wAFQEU7ROwFFKm5I6svkduwBKQ04sUiVTCyczADdNACMoCglbMEtnQmR0ABsoYjh2UmyNBgBeewYFOEDkZABiZAAeRv19AHdOCnZkI0Li60CUeqaWgwha2oABVRKsdNqG5v0J5A06ZHSBxGWVieEKBQZxkyUsHxtgiEy03HQEFDSnMABfAF0gA
+      shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhXER0AVwpFhEACZwGRBZwA6EfTqzdFFAPpV+FABS6wAFQEU7ROwFFKm5I6svkduwBKfRCIAAFVDQYsMg1rdAAbKGI4dlIEqIBeewYFOEDkZABiZAAeUv0NOmRLG0DEfULC4QoFBgg5UywfOv1CVApcdAQUMFqwAF8AXSA
     - title: Core
       file: app-variation-placeholder-rectangle-when-string-is-empty-core.py
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXZTmdKQYVkAQUxEG1ACZwGRAK6cAOhFUZ0AfSXIAvMiU4oAczia6AGyXSAFKuQODnLN3QKKmqgA8KdsABU4H2VCZBCAUUo5ZEDg0JCQgEoCe0dDUnc3D28PADc5ACMoCn4-HJCidAsoYjh2UgtZBl1-BgU4ZIcAYmQAHl7VRNVhiFk6Njl8hhtXdyIMiiyiVjhWVk5yRMRUhwABKVG5LBzuvoGIR2Qx5BybLZ3L5CkKBQYL2YosWN8htT+NPRiTA2DTaTjLSZyX6hMAUXDoBAoWFBChgAC+AF0gA

--- a/components/test_examples_smoke.py
+++ b/components/test_examples_smoke.py
@@ -12,7 +12,6 @@ import pytest
 from playwright.sync_api import Page
 
 from conftest import example_app_paths, launch_example_app
-from shiny.run import ShinyAppProc
 
 _COMPONENTS = Path(__file__).parent
 _APPS = example_app_paths()
@@ -25,35 +24,17 @@ assert len(_APPS) > 300, (
     "Discovery in example_app_paths() may be broken."
 )
 
-# Temporary opt-outs for apps that use shiny APIs newer than the pinned py-shiny
-# submodule. Remove these once the submodule is bumped. Tracked by:
-#   https://github.com/posit-dev/py-shiny-site/issues/397
-_ISSUE = "posit-dev/py-shiny-site#397"
-
-# App id -> stderr substrings to tolerate (e.g. a known deprecation the example
-# still uses). Deprecations are otherwise treated as errors.
-ALLOW_STDERR: dict[str, list[str]] = {
-    "display-messages/chat/app-preview.py": [
-        "ShinyDeprecationWarning: `Chat(messages=...)` is deprecated",
-        "chat = ui.Chat(",
-    ],
-}
-
-# App id -> reason. These can't even launch against the pinned shiny.
-XFAIL: dict[str, str] = {
-    "outputs/verbatim-text/app-variation-placeholder-rectangle-when-string-is-empty-express.py": (
-        f"shiny.express.ui.output_text_verbatim missing in pinned shiny ({_ISSUE})"
-    ),
-}
+# App id (path relative to components/) -> stderr substrings to tolerate for that
+# app (e.g. a known deprecation an example intentionally still demonstrates).
+# Deprecations are otherwise treated as errors. Empty today; kept as the plumbing
+# for future per-app opt-outs.
+ALLOW_STDERR: dict[str, list[str]] = {}
 
 
-def _param(app_path: Path):
-    rel = str(app_path.relative_to(_COMPONENTS))
-    marks = [pytest.mark.xfail(reason=XFAIL[rel], strict=True)] if rel in XFAIL else []
-    return pytest.param(app_path, id=rel, marks=marks)
-
-
-@pytest.mark.parametrize("app_path", [_param(p) for p in _APPS])
+@pytest.mark.parametrize(
+    "app_path",
+    [pytest.param(p, id=str(p.relative_to(_COMPONENTS))) for p in _APPS],
+)
 def test_example_app_smoke(page: Page, app_path: Path, smoke_test) -> None:
     rel = str(app_path.relative_to(_COMPONENTS))
     with launch_example_app(app_path) as app:


### PR DESCRIPTION
## Summary

The example-app smoke sweep (`make test-smoke` / `components/test_examples_smoke.py`) runs each `components/**/app-*.py` against the `shiny` pinned by the py-shiny submodule (**v1.6.3**). Two examples used APIs that aren't valid there and were temporarily whitelisted/xfailed, tracked by #397 (and its chat-specific follow-up #400).

Investigating against v1.6.3 (the latest release) showed both were **example bugs, not missing APIs** — so no submodule bump was needed:

- **Chat** — `chat.ui(messages=...)` already exists in v1.6.3; only `ui.Chat(messages=...)` is deprecated.
- **Verbatim-text (Express)** — `shiny.express.ui.output_text_verbatim(...)` never existed; Express is decorator-based and the placeholder is controlled via `@render.code(placeholder=True)`.

## Changes

- `components/display-messages/chat/app-preview.py` — move `messages=[welcome]` from the deprecated `ui.Chat(messages=...)` to `chat.ui(messages=...)`.
- `components/outputs/verbatim-text/app-variation-...-express.py` — replace the non-existent `ui.output_text_verbatim(placeholder=True)` + `ui.hold()` + `@render.text` with `@render.code(placeholder=True)`.
- `components/outputs/verbatim-text/index.qmd` — regenerate the Express variation's shinylive link.
- `components/test_examples_smoke.py` — remove the `XFAIL` dict and per-app xfail marking; keep an **empty `ALLOW_STDERR` dict** as plumbing for future per-app stderr opt-outs.

## Verification

- Both apps now pass the smoke sweep (chat no longer emits `ShinyDeprecationWarning`; the Express variation launches instead of xfailing).
- Suite still collects 307 tests (above the `>300` guard).

Closes #397
Closes #400