### PR TITLE
fix: expose ui.card_body in API docs (submodule bump) + drop dead ui.panel_well link

### DIFF
--- a/layouts/panels-cards/index.qmd
+++ b/layouts/panels-cards/index.qmd
@@ -30,9 +30,6 @@ listing:
   - title: ui.panel_fixed
     href: https://shiny.posit.co/py/api/ui.panel_fixed.html
     signature: ui.panel_fixed(*args, **kwargs)
-  - title: ui.panel_well
-    href: https://shiny.posit.co/py/api/ui.panel_well.html
-    signature: ui.panel_well(*args, **kwargs)
 - id: variation-hello-card
   template: ../../components/_partials/components-detail-example.ejs
   template-params:


### PR DESCRIPTION
## Summary

Fixes two 404ing API-reference links in the cards docs.

### 1. `ui.card_body` — submodule bump
`ui.card_body` / `express.ui.card_body` is public and exported but was missing from py-shiny's quartodoc configs, so no `api/ui.card_body.html` page was generated and links to it 404ed. This bumps the `py-shiny` submodule to latest `main`, which now includes posit-dev/py-shiny#2372 registering `card_body` in the core + express quartodoc sections. CI regenerates the page from the bumped submodule.

### 2. `ui.panel_well` — remove dead link
`layouts/panels-cards/index.qmd` listed `ui.panel_well` as a relevant function, but `panel_well` is **deprecated** (`@no_example()`, docstring: "Deprecated. Use \`shiny.ui.card()\` instead") and intentionally undocumented, so `api/ui.panel_well.html` 404s. Removed the entry — the list already points to `ui.card`, its replacement.

## Context
Found via a full sweep of every API-reference link in the docs; these were the only two real broken internal links (three other apparent hits were external pandas/polars doc URLs).