### PR TITLE
test: enforce a documentation page for every shiny.ui export

### DIFF
--- a/.claude/skills/writing-component-pages/SKILL.md
+++ b/.claude/skills/writing-component-pages/SKILL.md
@@ -148,6 +148,17 @@ See also: [Action Button](../action-button/index.qmd)
 - `relevant-functions` `href`s use the flat API-page form `https://shiny.posit.co/py/api/<name>.html`
   (NOT `/py/api/core/<name>.html` — the `/core/` path is a minority form). Use the real
   `signature`. For third-party outputs (e.g. Great Tables) link the package docs.
+- **List the component's mutator functions in `relevant-functions`, not just its
+  constructor.** Every server-side `update_<name>` / `insert_<name>` / `remove_<name>`
+  that pairs with the component belongs here as its own `title`/`href`/`signature`
+  entry (e.g. the Text Area page lists both `ui.input_text_area` and
+  `ui.update_text_area`; Accordion lists `ui.accordion` plus `update_accordion`,
+  `update_accordion_panel`, `insert_accordion_panel`, `remove_accordion_panel`). This
+  is enforced: `components/test_ui_api_has_page.py` checks that every public `ui`
+  export is documented by some page's `relevant-functions` block, and mutators are
+  expected to be found on their base component's page rather than opted out. Generate
+  each `signature` annotation-free to match the surrounding entries, e.g.
+  `python -c "import inspect, shiny.ui as u; s=inspect.signature(u.update_text_area); print('ui.update_text_area'+str(s.replace(parameters=[p.replace(annotation=inspect.Parameter.empty) for p in s.parameters.values()], return_annotation=inspect.Signature.empty)))"`.
 - Each variation's **Preview** app should be its own `app-variation-<slug>-preview.py`
   (same rule as the top-level Preview — no `shinylive:` key), not a reuse of its `-core.py`.
 
@@ -328,5 +339,6 @@ apps, sidebar placement — are things you (Claude) can only partially judge, so
 | Forgot `_quarto.yml` sidebar entry | Add the `index.qmd` path alphabetically in the right section |
 | Empty/half-made component dir left behind | Remove it; a dir under `components/*/` without `index.qmd` used to crash the link script |
 | Missing `sidebar: components` in front matter | Add it — required on every component page |
+| `relevant-functions` lists only the constructor, not the `update_*`/`insert_*`/`remove_*` mutators | Add an entry per mutator (title/href/signature); `test_ui_api_has_page.py` fails when a `ui` export is documented nowhere |
 | Shipping a demo whose buttons were never clicked (compiles ≠ works) | Run each interactive app and exercise every control in a browser; assert the visible effect, then save it as a `test_<name>.py` interaction test (see `testing-example-apps`) so CI keeps checking |
 | Copying a Core `ui.insert_*`/`ui.update_*` call verbatim into the Express demo | Check the Express signature — it can differ (e.g. `insert_accordion_panel`); copy py-shiny's `api-examples/<fn>/app-express.py` |

--- a/components/inputs/action-button/index.qmd
+++ b/components/inputs/action-button/index.qmd
@@ -28,6 +28,9 @@ listing:
   - title: reactive.event
     href: https://shiny.posit.co/py/api/reactive.event.html
     signature: reactive.event(*args, ignore_none=True, ignore_init=False)
+  - title: ui.update_action_button
+    href: https://shiny.posit.co/py/api/ui.update_action_button.html
+    signature: ui.update_action_button(id, *, label=None, icon=None, disabled=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/action-button/index.qmd
+++ b/components/inputs/action-button/index.qmd
@@ -30,7 +30,8 @@ listing:
     signature: reactive.event(*args, ignore_none=True, ignore_init=False)
   - title: ui.update_action_button
     href: https://shiny.posit.co/py/api/ui.update_action_button.html
-    signature: ui.update_action_button(id, *, label=None, icon=None, disabled=None, session=None)
+    signature: ui.update_action_button(id, *, label=None, icon=None, disabled=None,
+      session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/action-link/index.qmd
+++ b/components/inputs/action-link/index.qmd
@@ -28,6 +28,9 @@ listing:
   - title: reactive.event
     href: https://shiny.posit.co/py/api/reactive.event.html
     signature: reactive.event(*args, ignore_none=True, ignore_init=False)
+  - title: ui.update_action_link
+    href: https://shiny.posit.co/py/api/ui.update_action_link.html
+    signature: ui.update_action_link(id, *, label=None, icon=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/checkbox-group/index.qmd
+++ b/components/inputs/checkbox-group/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_checkbox_group.html
     signature: ui.input_checkbox_group(id, label, choices, *, selected=None, inline=False,
       width=None)
+  - title: ui.update_checkbox_group
+    href: https://shiny.posit.co/py/api/ui.update_checkbox_group.html
+    signature: ui.update_checkbox_group(id, *, label=None, choices=None, selected=None, inline=False, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/checkbox-group/index.qmd
+++ b/components/inputs/checkbox-group/index.qmd
@@ -28,7 +28,8 @@ listing:
       width=None)
   - title: ui.update_checkbox_group
     href: https://shiny.posit.co/py/api/ui.update_checkbox_group.html
-    signature: ui.update_checkbox_group(id, *, label=None, choices=None, selected=None, inline=False, session=None)
+    signature: ui.update_checkbox_group(id, *, label=None, choices=None, selected=None,
+      inline=False, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/checkbox/index.qmd
+++ b/components/inputs/checkbox/index.qmd
@@ -25,6 +25,9 @@ listing:
   - title: ui.input_checkbox()
     href: https://shiny.posit.co/py/api/ui.input_checkbox.html
     signature: ui.input_checkbox(id, label, value=False, *, width=None)
+  - title: ui.update_checkbox
+    href: https://shiny.posit.co/py/api/ui.update_checkbox.html
+    signature: ui.update_checkbox(id, *, label=None, value=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/dark-mode/index.qmd
+++ b/components/inputs/dark-mode/index.qmd
@@ -25,6 +25,9 @@ listing:
   - title: ui.input_dark_mode
     href: https://shiny.posit.co/py/api/ui.input_dark_mode.html
     signature: ui.input_dark_mode(id=None, mode=None, **kwargs)
+  - title: ui.update_dark_mode
+    href: https://shiny.posit.co/py/api/ui.update_dark_mode.html
+    signature: ui.update_dark_mode(mode, *, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/date-range-selector/index.qmd
+++ b/components/inputs/date-range-selector/index.qmd
@@ -29,7 +29,8 @@ listing:
       to ', width=None, autoclose=True)
   - title: ui.update_date_range
     href: https://shiny.posit.co/py/api/ui.update_date_range.html
-    signature: ui.update_date_range(id, *, label=None, start=None, end=None, min=None, max=None, session=None)
+    signature: ui.update_date_range(id, *, label=None, start=None, end=None, min=None,
+      max=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/date-range-selector/index.qmd
+++ b/components/inputs/date-range-selector/index.qmd
@@ -27,6 +27,9 @@ listing:
     signature: ui.input_date_range(id, label, *, start=None, end=None, min=None, max=None,
       format='yyyy-mm-dd', startview='month', weekstart=0, language='en', separator='
       to ', width=None, autoclose=True)
+  - title: ui.update_date_range
+    href: https://shiny.posit.co/py/api/ui.update_date_range.html
+    signature: ui.update_date_range(id, *, label=None, start=None, end=None, min=None, max=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/date-selector/index.qmd
+++ b/components/inputs/date-selector/index.qmd
@@ -27,6 +27,9 @@ listing:
     signature: ui.input_date(id, label, *, value=None, min=None, max=None, format='yyyy-mm-dd',
       startview='month', weekstart=0, language='en', width=None, autoclose=True, datesdisabled=None,
       daysofweekdisabled=None)
+  - title: ui.update_date
+    href: https://shiny.posit.co/py/api/ui.update_date.html
+    signature: ui.update_date(id, *, label=None, value=None, min=None, max=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/numeric-input/index.qmd
+++ b/components/inputs/numeric-input/index.qmd
@@ -28,7 +28,8 @@ listing:
       width=None)
   - title: ui.update_numeric
     href: https://shiny.posit.co/py/api/ui.update_numeric.html
-    signature: ui.update_numeric(id, *, label=None, value=None, min=None, max=None, step=None, session=None)
+    signature: ui.update_numeric(id, *, label=None, value=None, min=None, max=None,
+      step=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/numeric-input/index.qmd
+++ b/components/inputs/numeric-input/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_numeric.html
     signature: ui.input_numeric(id, label, value, *, min=None, max=None, step=None,
       width=None)
+  - title: ui.update_numeric
+    href: https://shiny.posit.co/py/api/ui.update_numeric.html
+    signature: ui.update_numeric(id, *, label=None, value=None, min=None, max=None, step=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/radio-buttons/index.qmd
+++ b/components/inputs/radio-buttons/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_radio_buttons.html
     signature: ui.input_radio_buttons(id, label, choices, *, selected=None, inline=False,
       width=None)
+  - title: ui.update_radio_buttons
+    href: https://shiny.posit.co/py/api/ui.update_radio_buttons.html
+    signature: ui.update_radio_buttons(id, *, label=None, choices=None, selected=None, inline=False, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/radio-buttons/index.qmd
+++ b/components/inputs/radio-buttons/index.qmd
@@ -28,7 +28,8 @@ listing:
       width=None)
   - title: ui.update_radio_buttons
     href: https://shiny.posit.co/py/api/ui.update_radio_buttons.html
-    signature: ui.update_radio_buttons(id, *, label=None, choices=None, selected=None, inline=False, session=None)
+    signature: ui.update_radio_buttons(id, *, label=None, choices=None, selected=None,
+      inline=False, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/select-multiple/index.qmd
+++ b/components/inputs/select-multiple/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_select.html
     signature: ui.input_select(id, label, choices, *, selected=None, multiple=False,
       selectize=False, width=None, size=None)
+  - title: ui.update_select
+    href: https://shiny.posit.co/py/api/ui.update_select.html
+    signature: ui.update_select(id, *, label=None, choices=None, selected=None, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/select-single/index.qmd
+++ b/components/inputs/select-single/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_select.html
     signature: ui.input_select(id, label, choices, *, selected=None, multiple=False,
       selectize=False, width=None, size=None)
+  - title: ui.update_select
+    href: https://shiny.posit.co/py/api/ui.update_select.html
+    signature: ui.update_select(id, *, label=None, choices=None, selected=None, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/selectize-multiple/index.qmd
+++ b/components/inputs/selectize-multiple/index.qmd
@@ -28,7 +28,8 @@ listing:
       width=None)
   - title: ui.update_selectize
     href: https://shiny.posit.co/py/api/ui.update_selectize.html
-    signature: ui.update_selectize(id, *, label=None, choices=None, selected=None, options=None, server=False, session=None)
+    signature: ui.update_selectize(id, *, label=None, choices=None, selected=None,
+      options=None, server=False, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/selectize-multiple/index.qmd
+++ b/components/inputs/selectize-multiple/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_selectize.html
     signature: ui.input_selectize(id, label, choices, *, selected=None, multiple=False,
       width=None)
+  - title: ui.update_selectize
+    href: https://shiny.posit.co/py/api/ui.update_selectize.html
+    signature: ui.update_selectize(id, *, label=None, choices=None, selected=None, options=None, server=False, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/selectize-single/index.qmd
+++ b/components/inputs/selectize-single/index.qmd
@@ -28,7 +28,8 @@ listing:
       width=None)
   - title: ui.update_selectize
     href: https://shiny.posit.co/py/api/ui.update_selectize.html
-    signature: ui.update_selectize(id, *, label=None, choices=None, selected=None, options=None, server=False, session=None)
+    signature: ui.update_selectize(id, *, label=None, choices=None, selected=None,
+      options=None, server=False, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/selectize-single/index.qmd
+++ b/components/inputs/selectize-single/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_selectize.html
     signature: ui.input_selectize(id, label, choices, *, selected=None, multiple=False,
       width=None)
+  - title: ui.update_selectize
+    href: https://shiny.posit.co/py/api/ui.update_selectize.html
+    signature: ui.update_selectize(id, *, label=None, choices=None, selected=None, options=None, server=False, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/slider-range/index.qmd
+++ b/components/inputs/slider-range/index.qmd
@@ -39,7 +39,8 @@ listing:
       summary=True, filters=False, row_selection_mode='none')
   - title: ui.update_slider
     href: https://shiny.posit.co/py/api/ui.update_slider.html
-    signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None, step=None, time_format=None, timezone=None, session=None)
+    signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None,
+      step=None, time_format=None, timezone=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/slider-range/index.qmd
+++ b/components/inputs/slider-range/index.qmd
@@ -37,6 +37,9 @@ listing:
     href: https://shiny.posit.co/py/api/render.DataTable.html
     signature: render.DataTable(self, data, *, width='fit-content', height='500px',
       summary=True, filters=False, row_selection_mode='none')
+  - title: ui.update_slider
+    href: https://shiny.posit.co/py/api/ui.update_slider.html
+    signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None, step=None, time_format=None, timezone=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/slider/index.qmd
+++ b/components/inputs/slider/index.qmd
@@ -27,6 +27,9 @@ listing:
     signature: ui.input_slider(id, label, min, max, value, *, step=None, ticks=False,
       animate=False, width=None, sep=',', pre=None, post=None, time_format=None, timezone=None,
       drag_range=True)
+  - title: ui.update_slider
+    href: https://shiny.posit.co/py/api/ui.update_slider.html
+    signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None, step=None, time_format=None, timezone=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/slider/index.qmd
+++ b/components/inputs/slider/index.qmd
@@ -29,7 +29,8 @@ listing:
       drag_range=True)
   - title: ui.update_slider
     href: https://shiny.posit.co/py/api/ui.update_slider.html
-    signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None, step=None, time_format=None, timezone=None, session=None)
+    signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None,
+      step=None, time_format=None, timezone=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/switch/index.qmd
+++ b/components/inputs/switch/index.qmd
@@ -25,6 +25,9 @@ listing:
   - title: ui.input_switch
     href: https://shiny.posit.co/py/api/ui.input_switch.html
     signature: ui.input_switch(id, label, value=False, *, width=None)
+  - title: ui.update_switch
+    href: https://shiny.posit.co/py/api/ui.update_switch.html
+    signature: ui.update_switch(id, *, label=None, value=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/text-area/index.qmd
+++ b/components/inputs/text-area/index.qmd
@@ -27,6 +27,9 @@ listing:
     signature: ui.input_text_area(id, label, value='', *, width=None, height=None,
       cols=None, rows=None, placeholder=None, resize=None, autoresize=False, autocomplete=None,
       spellcheck=None)
+  - title: ui.update_text_area
+    href: https://shiny.posit.co/py/api/ui.update_text_area.html
+    signature: ui.update_text_area(id, *, label=None, value=None, placeholder=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/text-area/index.qmd
+++ b/components/inputs/text-area/index.qmd
@@ -29,7 +29,8 @@ listing:
       spellcheck=None)
   - title: ui.update_text_area
     href: https://shiny.posit.co/py/api/ui.update_text_area.html
-    signature: ui.update_text_area(id, *, label=None, value=None, placeholder=None, session=None)
+    signature: ui.update_text_area(id, *, label=None, value=None, placeholder=None,
+      session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/text-box/index.qmd
+++ b/components/inputs/text-box/index.qmd
@@ -26,6 +26,9 @@ listing:
     href: https://shiny.posit.co/py/api/ui.input_text.html
     signature: ui.input_text(id, label, value='', *, width=None, placeholder=None,
       autocomplete='off', spellcheck=None)
+  - title: ui.update_text
+    href: https://shiny.posit.co/py/api/ui.update_text.html
+    signature: ui.update_text(id, *, label=None, value=None, placeholder=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/outputs/ui/index.qmd
+++ b/components/outputs/ui/index.qmd
@@ -35,7 +35,8 @@ listing:
       fill=False, fillable=False, **kwargs)
   - title: ui.insert_ui
     href: https://shiny.posit.co/py/api/ui.insert_ui.html
-    signature: ui.insert_ui(ui, selector, where='beforeEnd', multiple=False, immediate=False, session=None)
+    signature: ui.insert_ui(ui, selector, where='beforeEnd', multiple=False, immediate=False,
+      session=None)
   - title: ui.remove_ui
     href: https://shiny.posit.co/py/api/ui.remove_ui.html
     signature: ui.remove_ui(selector, multiple=False, immediate=False, session=None)

--- a/components/outputs/ui/index.qmd
+++ b/components/outputs/ui/index.qmd
@@ -33,6 +33,12 @@ listing:
     href: https://shiny.posit.co/py/api/express/express.render.express.html
     signature: express.render.express(self, _fn=None, *, inline=False, container=None,
       fill=False, fillable=False, **kwargs)
+  - title: ui.insert_ui
+    href: https://shiny.posit.co/py/api/ui.insert_ui.html
+    signature: ui.insert_ui(ui, selector, where='beforeEnd', multiple=False, immediate=False, session=None)
+  - title: ui.remove_ui
+    href: https://shiny.posit.co/py/api/ui.remove_ui.html
+    signature: ui.remove_ui(selector, multiple=False, immediate=False, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/outputs/value-box/index.qmd
+++ b/components/outputs/value-box/index.qmd
@@ -34,13 +34,16 @@ listing:
       fill=True, class_=None, **kwargs)
   - title: ui.showcase_left_center
     href: https://shiny.posit.co/py/api/ui.showcase_left_center.html
-    signature: ui.showcase_left_center(*, width='30%', width_full_screen='1fr', max_height='100px', max_height_full_screen='67%')
+    signature: ui.showcase_left_center(*, width='30%', width_full_screen='1fr', max_height='100px',
+      max_height_full_screen='67%')
   - title: ui.showcase_top_right
     href: https://shiny.posit.co/py/api/ui.showcase_top_right.html
-    signature: ui.showcase_top_right(*, width='40%', width_full_screen='1fr', max_height='75px', max_height_full_screen='67%')
+    signature: ui.showcase_top_right(*, width='40%', width_full_screen='1fr', max_height='75px',
+      max_height_full_screen='67%')
   - title: ui.showcase_bottom
     href: https://shiny.posit.co/py/api/ui.showcase_bottom.html
-    signature: ui.showcase_bottom(*, width='100%', width_full_screen=None, height='auto', height_full_screen='2fr', max_height='100px', max_height_full_screen=None)
+    signature: ui.showcase_bottom(*, width='100%', width_full_screen=None, height='auto',
+      height_full_screen='2fr', max_height='100px', max_height_full_screen=None)
   - title: ui.value_box_theme
     href: https://shiny.posit.co/py/api/ui.value_box_theme.html
     signature: ui.value_box_theme(name=None, *, fg=None, bg=None)

--- a/components/outputs/value-box/index.qmd
+++ b/components/outputs/value-box/index.qmd
@@ -32,6 +32,18 @@ listing:
     href: https://shiny.posit.co/py/api/ui.card.html#shiny.ui.card
     signature: ui.card(*args, full_screen=False, height=None, max_height=None, min_height=None,
       fill=True, class_=None, **kwargs)
+  - title: ui.showcase_left_center
+    href: https://shiny.posit.co/py/api/ui.showcase_left_center.html
+    signature: ui.showcase_left_center(*, width='30%', width_full_screen='1fr', max_height='100px', max_height_full_screen='67%')
+  - title: ui.showcase_top_right
+    href: https://shiny.posit.co/py/api/ui.showcase_top_right.html
+    signature: ui.showcase_top_right(*, width='40%', width_full_screen='1fr', max_height='75px', max_height_full_screen='67%')
+  - title: ui.showcase_bottom
+    href: https://shiny.posit.co/py/api/ui.showcase_bottom.html
+    signature: ui.showcase_bottom(*, width='100%', width_full_screen=None, height='auto', height_full_screen='2fr', max_height='100px', max_height_full_screen=None)
+  - title: ui.value_box_theme
+    href: https://shiny.posit.co/py/api/ui.value_box_theme.html
+    signature: ui.value_box_theme(name=None, *, fg=None, bg=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -91,8 +91,7 @@ _TODO_NEEDS_LAYOUT_PAGE = {
     "nav_control", "nav_menu", "nav_spacer", "navbar_options",
     "navset_bar", "navset_card_underline", "navset_hidden", "navset_underline",
     "page_auto", "page_bootstrap", "page_fluid", "page_opts", "page_output",
-    "page_sidebar", "panel_conditional", "panel_title", "showcase_bottom",
-    "showcase_left_center", "showcase_top_right", "value_box_theme",
+    "page_sidebar", "panel_conditional", "panel_title",
 }
 
 # Express-only / low-level helpers with no standalone component page.

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -68,17 +68,16 @@ _CLASSES = {
 # Plot brushing / click option builders.
 _OPTS = {"brush_opts", "click_opts", "dblclick_opts", "hover_opts"}
 
-# Mutators: ``update_*`` / ``insert_*`` / ``remove_*``. Documented on their base
-# component's page, which is enforced separately by that page existing.
+# Mutators (``update_*`` / ``insert_*`` / ``remove_*``) are documented in their
+# base component's ``relevant-functions`` block, not opted out. The only ones
+# still listed here are those whose base component has no page yet -- their
+# mutator should be added to that page's ``relevant-functions`` when it is
+# written (the base component is tracked in _TODO_NEEDS_COMPONENT_PAGE).
 _MUTATORS = {
-    "insert_nav_panel", "insert_ui", "remove_nav_panel", "remove_ui",
-    "update_action_button", "update_action_link", "update_checkbox",
-    "update_checkbox_group", "update_code_editor", "update_dark_mode",
-    "update_date", "update_date_range", "update_nav_panel", "update_navs",
-    "update_navset", "update_numeric", "update_popover", "update_radio_buttons",
-    "update_select", "update_selectize", "update_sidebar", "update_slider",
-    "update_submit_textarea", "update_switch", "update_task_button",
-    "update_text", "update_text_area",
+    "update_code_editor",       # base: input_code_editor
+    "update_popover",           # base: popover
+    "update_submit_textarea",   # base: input_submit_textarea
+    "update_task_button",       # base: input_task_button
 }
 
 # Deprecated / superseded functions that intentionally have no doc page.

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -1,0 +1,181 @@
+"""Verify every public ``ui`` export is documented by a component page.
+
+Each public function in ``shiny.ui.__all__`` and ``shiny.express.ui.__all__``
+should either be documented by a component page under ``components/`` -- listed
+in that page's ``relevant-functions`` front-matter block -- or be named in the
+``KNOWN_MISSING_COMPONENTS`` opt-out set below. A newly added ``ui`` export that
+is neither fails ``test_every_ui_export_has_a_page``, forcing a conscious
+"add a component page or opt out" decision.
+
+Coverage is read from the ``relevant-functions`` listing block already present in
+each ``components/**/index.qmd`` front matter (its ``title:`` entries name the
+documented functions, e.g. ``ui.input_action_button``); no dedicated registry is
+needed.
+
+This is a static filesystem check (no browser), so it runs under ``make test-apps``.
+It mirrors py-shiny's ``test_express_ui_is_complete`` (explicit opt-out set +
+staleness guard).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import shiny.express.ui
+import shiny.ui
+import yaml
+
+COMPONENTS_DIR = Path(__file__).parent
+
+# Every public ``ui`` export across the Core and Express APIs.
+API: set[str] = set(shiny.ui.__all__) | set(shiny.express.ui.__all__)
+
+# ``ui.<name>`` / ``express.ui.<name>`` from a page's ``relevant-functions``
+# ``title:`` (also tolerates a trailing ``()``, e.g. ``ui.input_checkbox()``).
+_TITLE_RE = re.compile(r"^(?:express\.)?ui\.([A-Za-z_][A-Za-z0-9_]*)")
+
+# ---------------------------------------------------------------------------
+# Opt-out set: exports that intentionally have no dedicated component page.
+# Grouped by reason so the list stays reviewable. Keep it honest -- the
+# staleness guard below fails if any entry is no longer a ``ui`` export.
+# ---------------------------------------------------------------------------
+
+# htmltools re-exports and tag / include helpers -- primitives, not components.
+_HTMLTOOLS = {
+    "HTML", "Tag", "TagList", "a", "br", "code", "div", "em",
+    "h1", "h2", "h3", "h4", "h5", "h6", "head_content", "hr", "img", "p",
+    "pre", "span", "strong", "tags", "markdown", "include_css", "include_js",
+    "js_eval", "help_text",
+}
+
+# Type aliases / option types -- not callable components.
+_TYPE_ALIASES = {
+    "AnimationOptions", "ShowcaseLayout", "SliderStepArg", "SliderValueArg",
+    "TagAttrValue", "TagAttrs", "TagChild",
+}
+
+# Classes returned/consumed by component functions (documented alongside them).
+_CLASSES = {
+    "AccordionPanel", "CardItem", "Chat", "MarkdownStream", "Sidebar", "Theme",
+    "ValueBoxTheme",
+}
+
+# Plot brushing / click option builders.
+_OPTS = {"brush_opts", "click_opts", "dblclick_opts", "hover_opts"}
+
+# Mutators: ``update_*`` / ``insert_*`` / ``remove_*``. Documented on their base
+# component's page, which is enforced separately by that page existing.
+_MUTATORS = {
+    "insert_nav_panel", "insert_ui", "remove_nav_panel", "remove_ui",
+    "update_action_button", "update_action_link", "update_checkbox",
+    "update_checkbox_group", "update_code_editor", "update_dark_mode",
+    "update_date", "update_date_range", "update_nav_panel", "update_navs",
+    "update_navset", "update_numeric", "update_popover", "update_radio_buttons",
+    "update_select", "update_selectize", "update_sidebar", "update_slider",
+    "update_submit_textarea", "update_switch", "update_task_button",
+    "update_text", "update_text_area",
+}
+
+# Layout / navigation / page / panel functions -- documented in ``layouts/``.
+_LAYOUT = {
+    "column", "row", "layout_column_wrap", "layout_columns", "layout_sidebar",
+    "sidebar", "nav_control", "nav_menu", "nav_panel", "nav_spacer",
+    "navbar_options", "navset_bar", "navset_card_pill", "navset_card_tab",
+    "navset_card_underline", "navset_hidden", "navset_pill", "navset_pill_list",
+    "navset_tab", "navset_underline", "page_auto", "page_bootstrap",
+    "page_fillable", "page_fixed", "page_fluid", "page_navbar", "page_opts",
+    "page_output", "page_sidebar", "panel_absolute", "panel_conditional",
+    "panel_fixed", "panel_title", "panel_well", "showcase_bottom",
+    "showcase_left_center", "showcase_top_right", "value_box_theme",
+}
+
+# Express-only / low-level helpers with no standalone component page.
+_MISC = {"busy_indicators", "fill", "hold"}
+
+# TODO: genuine components that should get their own component page. Move each
+# to a real page (and drop it from here) as pages are written.
+_TODO_NEEDS_PAGE = {
+    "bind_task_button", "chat_ui", "download_button", "download_link",
+    "input_bookmark_button", "input_code_editor", "input_submit_textarea",
+    "input_task_button", "output_code", "output_markdown_stream", "output_table",
+    "popover", "toast", "toast_header", "show_toast", "hide_toast",
+}
+
+KNOWN_MISSING_COMPONENTS: set[str] = (
+    _HTMLTOOLS
+    | _TYPE_ALIASES
+    | _CLASSES
+    | _OPTS
+    | _MUTATORS
+    | _LAYOUT
+    | _MISC
+    | _TODO_NEEDS_PAGE
+)
+
+
+def _documented_functions() -> set[str]:
+    """``ui`` function names named by any page's ``relevant-functions`` block."""
+    names: set[str] = set()
+    for qmd in COMPONENTS_DIR.glob("**/index.qmd"):
+        text = qmd.read_text()
+        if not text.startswith("---"):
+            continue
+        try:
+            front_matter = yaml.safe_load(text.split("---", 2)[1])
+        except yaml.YAMLError:
+            continue
+        if not isinstance(front_matter, dict):
+            continue
+        listing = front_matter.get("listing") or []
+        if isinstance(listing, dict):
+            listing = [listing]
+        for block in listing:
+            if not (isinstance(block, dict) and block.get("id") == "relevant-functions"):
+                continue
+            for item in block.get("contents") or []:
+                match = _TITLE_RE.match(str((item or {}).get("title", "")))
+                if match:
+                    names.add(match.group(1))
+    return names
+
+
+DOCUMENTED = _documented_functions()
+
+
+def test_documented_functions_discovered() -> None:
+    """Guard against a broken parser silently discovering nothing."""
+    assert len(DOCUMENTED) > 40, (
+        f"Expected >40 documented ui functions from relevant-functions blocks, "
+        f"found {len(DOCUMENTED)}. Front-matter parsing may be broken."
+    )
+
+
+def test_known_missing_are_real_exports() -> None:
+    """Keep the opt-out list honest: every entry must still be a ui export."""
+    stale = KNOWN_MISSING_COMPONENTS - API
+    assert not stale, (
+        f"KNOWN_MISSING_COMPONENTS names things that aren't ui exports anymore "
+        f"(stale/typo): {sorted(stale)}. Remove them."
+    )
+
+
+def test_documented_functions_are_real_exports() -> None:
+    """A relevant-functions entry must name an actual ui export (catch typos)."""
+    unknown = DOCUMENTED - API
+    assert not unknown, (
+        f"relevant-functions blocks reference ui functions that don't exist in "
+        f"shiny.ui / shiny.express.ui __all__: {sorted(unknown)}."
+    )
+
+
+def test_every_ui_export_has_a_page() -> None:
+    """Every public ui export is documented by a page or explicitly opted out."""
+    missing = API - DOCUMENTED - KNOWN_MISSING_COMPONENTS
+    assert not missing, (
+        f"These shiny.ui / shiny.express.ui exports have no component page: "
+        f"{sorted(missing)}.\n"
+        "For each: add it to a component page's `relevant-functions` front-matter "
+        "block, or add it to KNOWN_MISSING_COMPONENTS in this file (with the "
+        "right category group)."
+    )

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -88,10 +88,10 @@ _DEPRECATED = {"column", "row"}  # superseded by layout_columns / layout_column_
 # the source of truth for layout documentation -- once one of these appears
 # there (or on a component page) it is counted, so drop it from this list.
 _TODO_NEEDS_LAYOUT_PAGE = {
-    "nav_control", "nav_menu", "nav_spacer", "navbar_options",
+    "nav_spacer", "navbar_options",
     "navset_bar", "navset_card_underline", "navset_hidden", "navset_underline",
-    "page_auto", "page_bootstrap", "page_fluid", "page_opts", "page_output",
-    "page_sidebar", "panel_conditional", "panel_title",
+    "page_auto", "page_bootstrap", "page_opts", "page_output",
+    "panel_conditional",
 }
 
 # Express-only / low-level helpers with no standalone component page.

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -1,16 +1,16 @@
-"""Verify every public ``ui`` export is documented by a component page.
+"""Verify every public ``ui`` export is documented by a doc page.
 
 Each public function in ``shiny.ui.__all__`` and ``shiny.express.ui.__all__``
-should either be documented by a component page under ``components/`` -- listed
-in that page's ``relevant-functions`` front-matter block -- or be named in the
-``KNOWN_MISSING_COMPONENTS`` opt-out set below. A newly added ``ui`` export that
-is neither fails ``test_every_ui_export_has_a_page``, forcing a conscious
-"add a component page or opt out" decision.
+should either be documented by a page under ``components/`` or ``layouts/`` --
+listed in that page's ``relevant-functions`` front-matter block -- or be named in
+the ``KNOWN_MISSING_COMPONENTS`` opt-out set below. A newly added ``ui`` export
+that is neither fails ``test_every_ui_export_has_a_page``, forcing a conscious
+"add a doc page or opt out" decision.
 
 Coverage is read from the ``relevant-functions`` listing block already present in
-each ``components/**/index.qmd`` front matter (its ``title:`` entries name the
-documented functions, e.g. ``ui.input_action_button``); no dedicated registry is
-needed.
+each ``components/**/index.qmd`` and ``layouts/**/index.qmd`` front matter (its
+``title:`` entries name the documented functions, e.g.
+``ui.input_action_button``); no dedicated registry is needed.
 
 This is a static filesystem check (no browser), so it runs under ``make test-apps``.
 It mirrors py-shiny's ``test_express_ui_is_complete`` (explicit opt-out set +
@@ -27,6 +27,10 @@ import shiny.ui
 import yaml
 
 COMPONENTS_DIR = Path(__file__).parent
+REPO_ROOT = COMPONENTS_DIR.parent
+
+# Documentation sections whose pages carry ``relevant-functions`` front matter.
+DOC_DIRS = (COMPONENTS_DIR, REPO_ROOT / "layouts")
 
 # Every public ``ui`` export across the Core and Express APIs.
 API: set[str] = set(shiny.ui.__all__) | set(shiny.express.ui.__all__)
@@ -77,16 +81,14 @@ _MUTATORS = {
     "update_text", "update_text_area",
 }
 
-# Layout / navigation / page / panel functions -- documented in ``layouts/``.
+# Layout / navigation / page / panel functions with no doc page of their own.
+# (Many siblings -- e.g. layout_columns, sidebar, navset_tab -- ARE documented in
+# ``layouts/`` and so are counted, not opted out.)
 _LAYOUT = {
-    "column", "row", "layout_column_wrap", "layout_columns", "layout_sidebar",
-    "sidebar", "nav_control", "nav_menu", "nav_panel", "nav_spacer",
-    "navbar_options", "navset_bar", "navset_card_pill", "navset_card_tab",
-    "navset_card_underline", "navset_hidden", "navset_pill", "navset_pill_list",
-    "navset_tab", "navset_underline", "page_auto", "page_bootstrap",
-    "page_fillable", "page_fixed", "page_fluid", "page_navbar", "page_opts",
-    "page_output", "page_sidebar", "panel_absolute", "panel_conditional",
-    "panel_fixed", "panel_title", "panel_well", "showcase_bottom",
+    "column", "row", "nav_control", "nav_menu", "nav_spacer", "navbar_options",
+    "navset_bar", "navset_card_underline", "navset_hidden", "navset_underline",
+    "page_auto", "page_bootstrap", "page_fluid", "page_opts", "page_output",
+    "page_sidebar", "panel_conditional", "panel_title", "showcase_bottom",
     "showcase_left_center", "showcase_top_right", "value_box_theme",
 }
 
@@ -117,26 +119,27 @@ KNOWN_MISSING_COMPONENTS: set[str] = (
 def _documented_functions() -> set[str]:
     """``ui`` function names named by any page's ``relevant-functions`` block."""
     names: set[str] = set()
-    for qmd in COMPONENTS_DIR.glob("**/index.qmd"):
-        text = qmd.read_text()
-        if not text.startswith("---"):
-            continue
-        try:
-            front_matter = yaml.safe_load(text.split("---", 2)[1])
-        except yaml.YAMLError:
-            continue
-        if not isinstance(front_matter, dict):
-            continue
-        listing = front_matter.get("listing") or []
-        if isinstance(listing, dict):
-            listing = [listing]
-        for block in listing:
-            if not (isinstance(block, dict) and block.get("id") == "relevant-functions"):
+    for doc_dir in DOC_DIRS:
+        for qmd in doc_dir.glob("**/index.qmd"):
+            text = qmd.read_text()
+            if not text.startswith("---"):
                 continue
-            for item in block.get("contents") or []:
-                match = _TITLE_RE.match(str((item or {}).get("title", "")))
-                if match:
-                    names.add(match.group(1))
+            try:
+                front_matter = yaml.safe_load(text.split("---", 2)[1])
+            except yaml.YAMLError:
+                continue
+            if not isinstance(front_matter, dict):
+                continue
+            listing = front_matter.get("listing") or []
+            if isinstance(listing, dict):
+                listing = [listing]
+            for block in listing:
+                if not (isinstance(block, dict) and block.get("id") == "relevant-functions"):
+                    continue
+                for item in block.get("contents") or []:
+                    match = _TITLE_RE.match(str((item or {}).get("title", "")))
+                    if match:
+                        names.add(match.group(1))
     return names
 
 
@@ -173,9 +176,9 @@ def test_every_ui_export_has_a_page() -> None:
     """Every public ui export is documented by a page or explicitly opted out."""
     missing = API - DOCUMENTED - KNOWN_MISSING_COMPONENTS
     assert not missing, (
-        f"These shiny.ui / shiny.express.ui exports have no component page: "
+        f"These shiny.ui / shiny.express.ui exports have no doc page: "
         f"{sorted(missing)}.\n"
-        "For each: add it to a component page's `relevant-functions` front-matter "
-        "block, or add it to KNOWN_MISSING_COMPONENTS in this file (with the "
-        "right category group)."
+        "For each: add it to a components/ or layouts/ page's `relevant-functions` "
+        "front-matter block, or add it to KNOWN_MISSING_COMPONENTS in this file "
+        "(with the right category group)."
     )

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -81,10 +81,11 @@ _MUTATORS = {
     "update_text", "update_text_area",
 }
 
-# Layout / navigation / page / panel functions with no doc page of their own.
-# (Many siblings -- e.g. layout_columns, sidebar, navset_tab -- ARE documented in
-# ``layouts/`` and so are counted, not opted out.)
-_LAYOUT = {
+# TODO: layout / navigation / page / panel functions not yet documented in a
+# ``layouts/`` page. The ``layouts/`` files' ``relevant-functions`` blocks are
+# the source of truth for layout documentation -- once one of these appears
+# there (or on a component page) it is counted, so drop it from this list.
+_TODO_NEEDS_LAYOUT_PAGE = {
     "column", "row", "nav_control", "nav_menu", "nav_spacer", "navbar_options",
     "navset_bar", "navset_card_underline", "navset_hidden", "navset_underline",
     "page_auto", "page_bootstrap", "page_fluid", "page_opts", "page_output",
@@ -97,7 +98,7 @@ _MISC = {"busy_indicators", "fill", "hold"}
 
 # TODO: genuine components that should get their own component page. Move each
 # to a real page (and drop it from here) as pages are written.
-_TODO_NEEDS_PAGE = {
+_TODO_NEEDS_COMPONENT_PAGE = {
     "bind_task_button", "chat_ui", "download_button", "download_link",
     "input_bookmark_button", "input_code_editor", "input_submit_textarea",
     "input_task_button", "output_code", "output_markdown_stream", "output_table",
@@ -110,9 +111,9 @@ KNOWN_MISSING_COMPONENTS: set[str] = (
     | _CLASSES
     | _OPTS
     | _MUTATORS
-    | _LAYOUT
     | _MISC
-    | _TODO_NEEDS_PAGE
+    | _TODO_NEEDS_LAYOUT_PAGE
+    | _TODO_NEEDS_COMPONENT_PAGE
 )
 
 

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -81,12 +81,15 @@ _MUTATORS = {
     "update_text", "update_text_area",
 }
 
+# Deprecated / superseded functions that intentionally have no doc page.
+_DEPRECATED = {"column", "row"}  # superseded by layout_columns / layout_column_wrap
+
 # TODO: layout / navigation / page / panel functions not yet documented in a
 # ``layouts/`` page. The ``layouts/`` files' ``relevant-functions`` blocks are
 # the source of truth for layout documentation -- once one of these appears
 # there (or on a component page) it is counted, so drop it from this list.
 _TODO_NEEDS_LAYOUT_PAGE = {
-    "column", "row", "nav_control", "nav_menu", "nav_spacer", "navbar_options",
+    "nav_control", "nav_menu", "nav_spacer", "navbar_options",
     "navset_bar", "navset_card_underline", "navset_hidden", "navset_underline",
     "page_auto", "page_bootstrap", "page_fluid", "page_opts", "page_output",
     "page_sidebar", "panel_conditional", "panel_title", "showcase_bottom",
@@ -112,6 +115,7 @@ KNOWN_MISSING_COMPONENTS: set[str] = (
     | _OPTS
     | _MUTATORS
     | _MISC
+    | _DEPRECATED
     | _TODO_NEEDS_LAYOUT_PAGE
     | _TODO_NEEDS_COMPONENT_PAGE
 )

--- a/layouts/arrange/index.qmd
+++ b/layouts/arrange/index.qmd
@@ -20,6 +20,9 @@ listing:
   - title: ui.page_fillable
     href: https://shiny.posit.co/py/api/ui.page_fillable.html
     signature: ui.page_fillable(*args, padding=None, gap=None, fillable_mobile=False, title=None, lang=None, **kwargs)
+  - title: ui.page_fluid
+    href: https://shiny.posit.co/py/api/ui.page_fluid.html
+    signature: ui.page_fluid(*args, title=None, lang=None, theme=None, **kwargs)
 ---
 
 ```{python}

--- a/layouts/navbars/index.qmd
+++ b/layouts/navbars/index.qmd
@@ -14,6 +14,15 @@ listing:
   - title: ui.nav_panel
     href: https://shiny.posit.co/py/api/core/ui.nav_panel.html
     signature: ui.nav_panel(title, *args, value=None, icon=None)
+  - title: ui.update_nav_panel
+    href: https://shiny.posit.co/py/api/core/ui.update_nav_panel.html
+    signature: ui.update_nav_panel(id, target, method, session=None)
+  - title: ui.insert_nav_panel
+    href: https://shiny.posit.co/py/api/core/ui.insert_nav_panel.html
+    signature: ui.insert_nav_panel(id, nav_panel, target=None, position='after', select=False, session=None)
+  - title: ui.remove_nav_panel
+    href: https://shiny.posit.co/py/api/core/ui.remove_nav_panel.html
+    signature: ui.remove_nav_panel(id, target, session=None)
 ---
 
 ```{python}

--- a/layouts/panels-cards/index.qmd
+++ b/layouts/panels-cards/index.qmd
@@ -33,6 +33,9 @@ listing:
   - title: ui.panel_well
     href: https://shiny.posit.co/py/api/ui.panel_well.html
     signature: ui.panel_well(*args, **kwargs)
+  - title: ui.panel_title
+    href: https://shiny.posit.co/py/api/ui.panel_title.html
+    signature: ui.panel_title(title, window_title=<shiny.types.MISSING_TYPE object at 0x10529a720>)
 - id: variation-hello-card
   template: ../../components/_partials/components-detail-example.ejs
   template-params:

--- a/layouts/sidebars/index.qmd
+++ b/layouts/sidebars/index.qmd
@@ -16,6 +16,9 @@ listing:
   - title: ui.sidebar
     href: https://shiny.posit.co/py/api/ui.sidebar.html#shiny.ui.sidebar
     signature: ui.sidebar(*args, width=250, position='left', open='desktop', id=None, title=None, bg=None, fg=None, class_=None, max_height_mobile=None, gap=None, padding=None)
+  - title: ui.update_sidebar
+    href: https://shiny.posit.co/py/api/ui.update_sidebar.html
+    signature: ui.update_sidebar(id, *, show=None, session=None)
 ---
 
 ```{python}

--- a/layouts/sidebars/index.qmd
+++ b/layouts/sidebars/index.qmd
@@ -19,6 +19,9 @@ listing:
   - title: ui.update_sidebar
     href: https://shiny.posit.co/py/api/ui.update_sidebar.html
     signature: ui.update_sidebar(id, *, show=None, session=None)
+  - title: ui.page_sidebar
+    href: https://shiny.posit.co/py/api/ui.page_sidebar.html
+    signature: ui.page_sidebar(sidebar, *args, title=None, fillable=False, fillable_mobile=False, window_title=<shiny.types.MISSING_TYPE object at 0x10529a720>, lang=None, theme=None, **kwargs)
 ---
 
 ```{python}

--- a/layouts/tabs/index.qmd
+++ b/layouts/tabs/index.qmd
@@ -40,6 +40,15 @@ listing:
   - title: ui.update_navset
     href: https://shiny.posit.co/py/api/ui.update_navset.html
     signature: ui.update_navset(id, selected=None, session=None)
+  - title: ui.nav_control
+    href: https://shiny.posit.co/py/api/ui.nav_control.html
+    signature: ui.nav_control(*args)
+  - title: ui.nav_menu
+    href: https://shiny.posit.co/py/api/ui.nav_menu.html
+    signature: ui.nav_menu(title, *args, value=None, icon=None, align='left')
+  - title: ui.nav_panel
+    href: https://shiny.posit.co/py/api/ui.nav_panel.html
+    signature: ui.nav_panel(title, *args, value=None, icon=None)
 ---
 
 ```{python}

--- a/layouts/tabs/index.qmd
+++ b/layouts/tabs/index.qmd
@@ -34,6 +34,12 @@ listing:
   - title: ui.navset_tab
     href: https://shiny.posit.co/py/api/ui.navset_tab.html
     signature: ui.navset_tab(*args, id=None, selected=None, header=None, footer=None)
+  - title: ui.update_navs
+    href: https://shiny.posit.co/py/api/ui.update_navs.html
+    signature: ui.update_navs(id, selected=None, session=None)
+  - title: ui.update_navset
+    href: https://shiny.posit.co/py/api/ui.update_navset.html
+    signature: ui.update_navset(id, selected=None, session=None)
 ---
 
 ```{python}


### PR DESCRIPTION
## Summary

Adds `components/test_ui_api_has_page.py`, a static (no-browser) test that guards against silent documentation gaps: every public export in `shiny.ui.__all__` and `shiny.express.ui.__all__` must either be documented by a page under `components/` or `layouts/`, or be named in the explicit `KNOWN_MISSING_COMPONENTS` opt-out set. A newly added `ui` export that is neither fails the test, forcing a conscious "add a page or opt out" decision. It mirrors py-shiny's own `test_express_ui_is_complete` pattern (explicit opt-out + staleness guard).

Coverage is read from the `relevant-functions` listing block already present in each page's `index.qmd` front matter (its `title:` entries name the documented functions) — the `layouts/` files are treated as the source of truth for layout documentation, so no separate registry is introduced. The opt-out set is grouped by reason (htmltools primitives, type aliases, return classes, `*_opts` builders, deprecated `column`/`row`, misc helpers, and two clearly-labelled TODO backlogs). Three supporting assertions keep it honest: a discovery guard (parser can't vacuously pass), a staleness guard (no opting out a name that isn't an export), and a typo guard (a `relevant-functions` entry must name a real export).

While wiring this up, the branch also closes real coverage gaps in the docs themselves: every `update_*` / `insert_*` / `remove_*` mutator is now listed in its base component/layout page's `relevant-functions` block (Text Area lists `update_text_area`, Accordion lists its four mutators, etc.); `showcase_*` and `value_box_theme` were added to the Value Box page; and on-topic nav/page/panel functions actually used in the layout demos (`nav_control`, `nav_menu`, `nav_panel` on Tabs; `page_fluid` on Arrange; `page_sidebar` on Sidebars; `panel_title` on Panels & Cards) were added to those pages. The `writing-component-pages` skill was updated to instruct authors to list mutators in `relevant-functions`. These edits touch only `index.qmd` front matter (no `app-*.py`), so the `test-shinylive-links` CI check is unaffected.

Current coverage: 98 of 179 exports documented, 81 intentionally opted out.

## Verification

```bash
uv run --no-project pytest components/test_ui_api_has_page.py -v
# 4 passed
```

The test is auto-collected by `make test-apps` (pytest `testpaths = components`). To see the guard work, remove any documented export from its page's `relevant-functions` block (or add a bogus name to `KNOWN_MISSING_COMPONENTS`) and re-run — the coverage / staleness assertion fails with an actionable message.

## Open TODOs (tracked in the test as opt-out groups; out of scope here)

These are genuine documentation gaps, not test problems. Each is a separate page-writing effort. They live in named sets in `test_ui_api_has_page.py` so they're visible and enforced-once-fixed:

**`_TODO_NEEDS_COMPONENT_PAGE` — components lacking a page (16):** `bind_task_button`, `chat_ui`, `download_button`, `download_link`, `hide_toast`, `input_bookmark_button`, `input_code_editor`, `input_submit_textarea`, `input_task_button`, `output_code`, `output_markdown_stream`, `output_table`, `popover`, `show_toast`, `toast`, `toast_header`.

**`_TODO_NEEDS_LAYOUT_PAGE` — layout/nav/page functions lacking a page or entry (11):** `nav_spacer`, `navbar_options`, `navset_bar`, `navset_card_underline`, `navset_hidden`, `navset_underline`, `page_auto`, `page_bootstrap`, `page_opts`, `page_output`, `panel_conditional`.

**`_MUTATORS` — mutators whose base component has no page yet (4):** `update_code_editor`, `update_popover`, `update_submit_textarea`, `update_task_button`. Each should move onto its base component's `relevant-functions` block when that page is written.

Separately, #405 tracks keeping the hand-authored `title`/`href`/`signature` fields in `relevant-functions` in sync with the API (the new signatures added here are hand-generated, annotation-free, and share that limitation).