### PR TITLE
feat: generate relevant-functions href/signature from the shiny.ui API (#405)

### DIFF
--- a/.claude/skills/writing-component-pages/SKILL.md
+++ b/.claude/skills/writing-component-pages/SKILL.md
@@ -38,7 +38,7 @@ components/inputs/<name>/
 
 | File | Rendered as | Style |
 |------|-------------|-------|
-| `app-preview.py` | Gallery-list card (via `appPreview:` + `make components-static`) | Core, module-level `app_ui`, viewport-filling (`vh-100 d-flex justify-content-center align-items-center`) |
+| `app-preview.py` | Gallery-list card (via `appPreview:` + `make components-static-previews`) | Core, module-level `app_ui`, viewport-filling (`vh-100 d-flex justify-content-center align-items-center`) |
 | `app-detail-preview.py` | Live standalone app at top of `#example` (the "Preview" tab) | Core, module-level `app_ui`; may use `## file: app.py` multi-file marker |
 | `app-core.py` / `app-express.py` | Static code blocks in the Core/Express tabs, each with an "Open in editor" shinylive link | Idiomatic Core / Express; mark the key line with a trailing `# <<` comment |
 | `app-variation-*-{core,express}.py` | One entry in the `#variations` block | Same as core/express |
@@ -195,7 +195,7 @@ With no `FILES`, it rewrites every component page (what CI does).
 
 ## Static preview cards
 
-`make components-static` (script: `components/make-static-previews.py`) walks every
+`make components-static-previews` (script: `components/make-static-previews.py`) walks every
 `index.qmd`, and for each with `appPreview.static: true` renders `appPreview.file` to
 `components/static/.../*.html`. This is why `app-preview.py` must expose a module-level
 `app_ui` and should be laid out to look good centered in a small card.
@@ -213,7 +213,7 @@ The four sections are `inputs`, `outputs`, `display-messages`, `layout`.
 ## Build & verify
 
 ```bash
-make components        # = components-shinylive-links + components-static
+make components        # = components-shinylive-links + components-relevant-functions + components-static-previews
 make serve             # live preview; open the new page
 ```
 

--- a/.github/internal/setup-py-shiny-site/action.yml
+++ b/.github/internal/setup-py-shiny-site/action.yml
@@ -1,15 +1,18 @@
 name: Set up py-shiny-site
 description: >
   Shared environment setup for py-shiny-site workflows: install uv (with the
-  Python version from the Makefile) and check out the pinned py-shiny submodule.
-  Requires the repo to already be checked out (`actions/checkout`) first -- a
-  local action cannot check out the repo it lives in. Exposes the resolved
-  Python version as the `python-version` output.
+  Python version from the Makefile), install Quarto (version from the Makefile),
+  and check out the pinned py-shiny submodule. Requires the repo to already be
+  checked out (`actions/checkout`) first -- a local action cannot check out the
+  repo it lives in. Exposes the resolved Python and Quarto versions as outputs.
 
 outputs:
   python-version:
     description: The Python version read from the Makefile.
     value: ${{ steps.uv.outputs.python-version }}
+  quarto-version:
+    description: The Quarto version read from the Makefile.
+    value: ${{ steps.quarto.outputs.quarto-version }}
 
 runs:
   using: composite
@@ -17,6 +20,12 @@ runs:
     - name: Set up uv
       id: uv
       uses: ./.github/internal/setup-uv
+
+    # Quarto (version pinned in the Makefile). Needed by workflows that run
+    # quartodoc / render the site; a no-op-cheap add for the rest.
+    - name: Set up Quarto
+      id: quarto
+      uses: ./.github/internal/setup-quarto
 
     # `make deps` builds the shiny package from the pinned submodule commit, so
     # the installed controllers/version match the site build.

--- a/.github/internal/setup-quarto/action.yml
+++ b/.github/internal/setup-quarto/action.yml
@@ -1,0 +1,32 @@
+name: Set up Quarto (version from Makefile)
+description: >
+  Read QUARTO_VERSION from the repo Makefile (single source of truth) and
+  install Quarto at that version via quarto-dev/quarto-actions/setup. Requires
+  the repo to be checked out first. Exposes the resolved version as the
+  `quarto-version` output.
+
+outputs:
+  quarto-version:
+    description: The Quarto version read from the Makefile.
+    value: ${{ steps.quarto-version.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    # Single source of truth: the Makefile's `QUARTO_VERSION ?= ...` pins the
+    # Quarto version, so read it here rather than hardcoding it per workflow.
+    - name: Read Quarto version from Makefile
+      id: quarto-version
+      shell: bash
+      run: |
+        version="$(sed -n 's/^QUARTO_VERSION[[:space:]]*?=[[:space:]]*//p' Makefile | head -n1)"
+        if [ -z "$version" ]; then
+          echo "::error::Could not read QUARTO_VERSION from Makefile"
+          exit 1
+        fi
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+    - name: Install Quarto
+      uses: quarto-dev/quarto-actions/setup@v2
+      with:
+        version: ${{ steps.quarto-version.outputs.version }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -39,11 +39,9 @@ jobs:
       # =====================================================
       # Install dependencies
       # =====================================================
+      # Sets up uv + Quarto (versions from the Makefile) + the py-shiny submodule.
       - name: Set up py-shiny-site
         uses: ./.github/internal/setup-py-shiny-site
-
-      # Install Quarto at the version pinned in the Makefile (QUARTO_VERSION).
-      - uses: ./.github/internal/setup-quarto
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -15,9 +15,6 @@ concurrency:
   group: site-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  QUARTO_VERSION: 1.9.36
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -45,10 +42,8 @@ jobs:
       - name: Set up py-shiny-site
         uses: ./.github/internal/setup-py-shiny-site
 
-      - uses: quarto-dev/quarto-actions/setup@v2
-        id: quarto
-        with:
-          version: ${{ env.QUARTO_VERSION }}
+      # Install Quarto at the version pinned in the Makefile (QUARTO_VERSION).
+      - uses: ./.github/internal/setup-quarto
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/test-relevant-functions.yml
+++ b/.github/workflows/test-relevant-functions.yml
@@ -26,8 +26,12 @@ jobs:
       # target depends on quartodoc (which regenerates the api/** pages and needs
       # the quarto binary set up above). QUARTO_PATH=quarto points the Makefile
       # at that quarto; `install-quarto`'s CI branch just checks it is on PATH.
+      #
+      # RELEVANT_FUNCTIONS_STRICT=1 makes an unresolvable (rotted/renamed) title
+      # fail here rather than be silently left as-authored: unlike the build/setup
+      # chain, which falls forward, CI requires the fields to be correct.
       - name: Regenerate relevant-functions fields
-        run: make components-relevant-functions QUARTO_PATH=quarto
+        run: make components-relevant-functions QUARTO_PATH=quarto RELEVANT_FUNCTIONS_STRICT=1
 
       # If regenerating changed any tracked file, the committed fields are stale.
       - name: Verify relevant-functions are up to date

--- a/.github/workflows/test-relevant-functions.yml
+++ b/.github/workflows/test-relevant-functions.yml
@@ -16,20 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Installs uv + checks out the pinned py-shiny submodule so the generated
-      # API pages (the generator's input) match the site build.
+      # Installs uv + Quarto (versions from the Makefile) + checks out the pinned
+      # py-shiny submodule so the generated API pages (the generator's input)
+      # match the site build.
       - name: Set up py-shiny-site
         uses: ./.github/internal/setup-py-shiny-site
 
-      # The generator depends on `quartodoc`, which regenerates the api/** pages
-      # it reads -- and quartodoc needs the quarto binary. `install-quarto`'s CI
-      # branch just checks quarto is on PATH, so install it here (version pinned
-      # in the Makefile, same as site.yml).
-      - uses: ./.github/internal/setup-quarto
-
       # Regenerate href/signature in the component/layout index.qmd files. The
-      # target depends on quartodoc, so the API pages are generated first.
-      # QUARTO_PATH=quarto points the Makefile at the quarto installed above.
+      # target depends on quartodoc (which regenerates the api/** pages and needs
+      # the quarto binary set up above). QUARTO_PATH=quarto points the Makefile
+      # at that quarto; `install-quarto`'s CI branch just checks it is on PATH.
       - name: Regenerate relevant-functions fields
         run: make components-relevant-functions QUARTO_PATH=quarto
 

--- a/.github/workflows/test-relevant-functions.yml
+++ b/.github/workflows/test-relevant-functions.yml
@@ -10,6 +10,9 @@ concurrency:
   group: test-relevant-functions-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  QUARTO_VERSION: 1.9.36
+
 jobs:
   test-relevant-functions:
     runs-on: ubuntu-latest
@@ -21,10 +24,18 @@ jobs:
       - name: Set up py-shiny-site
         uses: ./.github/internal/setup-py-shiny-site
 
+      # The generator depends on `quartodoc`, which regenerates the api/** pages
+      # it reads -- and quartodoc needs the quarto binary. `install-quarto`'s CI
+      # branch just checks quarto is on PATH, so install it here (as site.yml does).
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: ${{ env.QUARTO_VERSION }}
+
       # Regenerate href/signature in the component/layout index.qmd files. The
       # target depends on quartodoc, so the API pages are generated first.
+      # QUARTO_PATH=quarto points the Makefile at the quarto installed above.
       - name: Regenerate relevant-functions fields
-        run: make components-relevant-functions
+        run: make components-relevant-functions QUARTO_PATH=quarto
 
       # If regenerating changed any tracked file, the committed fields are stale.
       - name: Verify relevant-functions are up to date

--- a/.github/workflows/test-relevant-functions.yml
+++ b/.github/workflows/test-relevant-functions.yml
@@ -10,9 +10,6 @@ concurrency:
   group: test-relevant-functions-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  QUARTO_VERSION: 1.9.36
-
 jobs:
   test-relevant-functions:
     runs-on: ubuntu-latest
@@ -26,10 +23,9 @@ jobs:
 
       # The generator depends on `quartodoc`, which regenerates the api/** pages
       # it reads -- and quartodoc needs the quarto binary. `install-quarto`'s CI
-      # branch just checks quarto is on PATH, so install it here (as site.yml does).
-      - uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: ${{ env.QUARTO_VERSION }}
+      # branch just checks quarto is on PATH, so install it here (version pinned
+      # in the Makefile, same as site.yml).
+      - uses: ./.github/internal/setup-quarto
 
       # Regenerate href/signature in the component/layout index.qmd files. The
       # target depends on quartodoc, so the API pages are generated first.

--- a/.github/workflows/test-relevant-functions.yml
+++ b/.github/workflows/test-relevant-functions.yml
@@ -1,0 +1,38 @@
+name: test-relevant-functions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: test-relevant-functions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-relevant-functions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Installs uv + checks out the pinned py-shiny submodule so the generated
+      # API pages (the generator's input) match the site build.
+      - name: Set up py-shiny-site
+        uses: ./.github/internal/setup-py-shiny-site
+
+      # Regenerate href/signature in the component/layout index.qmd files. The
+      # target depends on quartodoc, so the API pages are generated first.
+      - name: Regenerate relevant-functions fields
+        run: make components-relevant-functions
+
+      # If regenerating changed any tracked file, the committed fields are stale.
+      - name: Verify relevant-functions are up to date
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::relevant-functions href/signature are out of date. Run 'make components-relevant-functions' and commit the result."
+            echo "--- Offending diff ---"
+            git diff
+            exit 1
+          fi
+          echo "relevant-functions are up to date."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ make components-shinylive-links
 make components-shinylive-links FILES="components/inputs/action-button/app-core.py"
 
 # Generate static component previews
-make components-static
+make components-static-previews
 ```
 
 ### Virtual Environment
@@ -285,7 +285,7 @@ To update component examples:
 make components-shinylive-links
 
 # Regenerate static preview images
-make components-static
+make components-static-previews
 ```
 
 **Always regenerate the Shinylive links after editing any `app-*.py` file** and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,8 @@ All code examples use Shinylive to run Python in the browser via WebAssembly. Th
 
 - **`test-shinylive-links`** (`.github/workflows/test-shinylive-links.yml`) — on every PR, regenerates the component Shinylive links (`make components-shinylive-links`) and **fails if the committed links differ**. This catches an edited `app-*.py` whose `shinylive:` link in `index.qmd` wasn't regenerated. It installs the py-shiny submodule + full `deps` so the shinylive version matches the site build, and reads `PYTHON_VERSION` from the Makefile. Fix a failure by running `make components-shinylive-links` and committing the updated `index.qmd` files.
 
+- **`test-relevant-functions`** (`.github/workflows/test-relevant-functions.yml`) — on every PR, regenerates the `relevant-functions` front-matter fields (`make components-relevant-functions`) and **fails if the committed `index.qmd` files differ**. This catches a `title`/`href`/`signature` in a component or layout page's `relevant-functions` block that drifted from the live `shiny.ui` / `shiny.express.ui` API (e.g. after a py-shiny submodule bump). It sets up the submodule + `deps` and runs `quartodoc` first (the generator reads the generated `api/**` pages). Fix a failure by running `make components-relevant-functions` and committing the updated `index.qmd` files.
+
 ## Working with Components
 
 Component pages follow a consistent structure:
@@ -291,6 +293,8 @@ commit the updated `index.qmd`. The `shinylive:` values encode the app source, s
 a stale link ships the wrong code — and the `test-shinylive-links` CI workflow
 fails the PR when committed links are out of date.
 
+**Regenerate the `relevant-functions` fields** with `make components-relevant-functions` whenever you add a new component/layout page (or edit its `relevant-functions` block), bump the py-shiny submodule, or otherwise change the documented API — the `title`/`href`/`signature` values are generated from the `api/**` reference pages, and the `test-relevant-functions` CI workflow fails the PR when committed values are stale.
+
 ## Working with API Documentation
 
 API docs are generated from the py-shiny repository:
@@ -298,6 +302,7 @@ API docs are generated from the py-shiny repository:
 1. Update py-shiny submodule if needed: `make submodules-pull`
 2. Regenerate docs: `make quartodoc`
 3. Docs appear in `api/express/`, `api/core/`, `api/testing/`
+4. Regenerate the component/layout `relevant-functions` fields: `make components-relevant-functions` (the `title`/`href`/`signature` values are generated from the `api/**` pages, so a submodule bump can change them). Commit the updated `index.qmd` files.
 
 The custom renderer automatically extracts examples from `py-shiny/shiny/examples/{function_name}/` and embeds them as interactive Shinylive demos.
 

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ quartodoc: $(PYBIN) deps install-quarto
 
 ## Build component static previews and update shinylive links
 .PHONY: components
-components: components-shinylive-links components-static
+components: components-shinylive-links components-relevant-functions components-static
 
 .PHONY: components-static
 components-static: $(PYBIN) deps
@@ -197,6 +197,12 @@ components-static: $(PYBIN) deps
 .PHONY: components-shinylive-links
 components-shinylive-links: $(PYBIN) deps
 	$(UVRUN) python components/update-shinylive-links.py $(FILES)
+
+## Regenerate relevant-functions href/signature from the API pages; pass
+## FILES="dir-or-file ..." to limit to those pages
+.PHONY: components-relevant-functions
+components-relevant-functions: $(PYBIN) deps quartodoc
+	$(UVRUN) python components/update-relevant-functions.py $(FILES)
 
 # Install the Playwright browser used by `make test` (idempotent; ~no-op once
 # present). Skipped when a remote Playwright server is configured

--- a/Makefile
+++ b/Makefile
@@ -199,10 +199,17 @@ components-shinylive-links: $(PYBIN) deps
 	$(UVRUN) python components/update-shinylive-links.py $(FILES)
 
 ## Regenerate relevant-functions href/signature from the API pages; pass
-## FILES="dir-or-file ..." to limit to those pages
+## FILES="dir-or-file ..." to limit to those pages.
+##
+## The build/setup chain "falls forward": an unresolvable (rotted/renamed)
+## title is warned about and left as-authored so it never aborts a local build
+## or `make ai-setup`. CI sets RELEVANT_FUNCTIONS_STRICT=1 so the same rot
+## fails the check -- the correct fields are still required before merge.
+RELEVANT_FUNCTIONS_STRICT ?=
 .PHONY: components-relevant-functions
 components-relevant-functions: $(PYBIN) deps quartodoc
-	$(UVRUN) python components/update-relevant-functions.py $(FILES)
+	$(UVRUN) python components/update-relevant-functions.py \
+		$(if $(RELEVANT_FUNCTIONS_STRICT),--strict,--no-strict) $(FILES)
 
 # Install the Playwright browser used by `make test` (idempotent; ~no-op once
 # present). Skipped when a remote Playwright server is configured

--- a/Makefile
+++ b/Makefile
@@ -186,10 +186,10 @@ quartodoc: $(PYBIN) deps install-quarto
 
 ## Build component static previews and update shinylive links
 .PHONY: components
-components: components-shinylive-links components-relevant-functions components-static
+components: components-shinylive-links components-relevant-functions components-static-previews
 
-.PHONY: components-static
-components-static: $(PYBIN) deps
+.PHONY: components-static-previews
+components-static-previews: $(PYBIN) deps
 	rm -rf components/static
 	$(UVRUN) python components/make-static-previews.py
 

--- a/components/_qmd.py
+++ b/components/_qmd.py
@@ -3,6 +3,19 @@ import os
 import yaml as yml
 
 
+class _QmdDumper(yml.Dumper):
+    pass
+
+
+def _represent_str(dumper, data):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_QmdDumper.add_representer(str, _represent_str)
+
+
 def find_qmds(dir, exclude):
     qmd_list = [p for p in os.listdir(dir) if p.endswith(".qmd")]
     qmd_list = [os.path.join(dir, p) for p in qmd_list if p not in exclude]
@@ -64,7 +77,11 @@ def write_qmd(qmd, path):
 
     with open(path, "w") as f:
         f.write("---\n")
-        f.write(yml.dump(meta, sort_keys=False, indent=2, default_flow_style=False))
+        f.write(
+            yml.dump(
+                meta, Dumper=_QmdDumper, sort_keys=False, indent=2, default_flow_style=False
+            )
+        )
         f.write("---\n\n")
         f.write(body.strip())
         f.write("\n")

--- a/components/_relevant_functions.py
+++ b/components/_relevant_functions.py
@@ -1,0 +1,119 @@
+"""Resolve relevant-functions title -> (href, signature) from generated API pages.
+
+The quartodoc-generated ``api/core/*.qmd`` pages are the single source of truth:
+each documented object renders a ``{ #shiny.<qualified-name> }`` anchor followed
+by a fenced ``python`` code block holding the exact signature convention (param
+names + defaults, annotations stripped). We parse that rather than re-deriving
+the convention from ``inspect.signature``.
+
+Resolution is core-consistent: always ``api/core`` (never the express page,
+which renders a different context-manager signature).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+API_BASE_URL = "https://shiny.posit.co/py/api/core"
+
+
+class TitleResolutionError(Exception):
+    """A relevant-functions ``title`` could not be resolved to an API page."""
+
+
+# Titles intentionally NOT generated (left hand-authored). Grouped by reason so
+# the list stays reviewable.
+
+# External packages with no page in this site's api/ tree.
+_EXTERNAL = {
+    "@shinywidgets.render_widget()",
+    "shinywidgets.output_widget",
+}
+
+# Chat is documented against an *instance* (``chat = ui.Chat()``) so its titles
+# use instance/decorator forms that intentionally differ from the class API.
+_CHAT_INSTANCE = {
+    "@chat.on_user_submit",
+    "chat = ui.Chat()",
+    "chat.append_message()",
+    "chat.append_message_stream()",
+    "chat.ui()",
+}
+
+SKIP_TITLES: set[str] = _EXTERNAL | _CHAT_INSTANCE
+
+
+def normalize_title(title: str) -> str:
+    """Strip a leading ``@``, a trailing ``(...)``, and a leading ``express.``."""
+    t = title.strip()
+    if t.startswith("@"):
+        t = t[1:]
+    t = t.split("(", 1)[0].strip()
+    if t.startswith("express."):
+        t = t[len("express.") :]
+    return t
+
+
+def flatten_python_block(block: str) -> str:
+    """Collapse a multi-line rendered signature into one logical line."""
+    # Join every line, drop indentation/newlines, normalize inter-arg spacing.
+    joined = " ".join(line.strip() for line in block.strip().splitlines())
+    joined = re.sub(r"\s+", " ", joined)
+    # Remove a space after "(" and before ")", and the trailing comma before ")".
+    joined = joined.replace("( ", "(").replace(" )", ")")
+    joined = joined.replace(", )", ")").replace(",)", ")")
+    return joined.strip()
+
+
+def extract_signature_block(qmd_text: str, anchor: str) -> str:
+    """Flattened signature for the section whose header carries ``{ #anchor }``."""
+    marker = f"{{ #{anchor} }}"
+    idx = qmd_text.find(marker)
+    if idx == -1:
+        raise TitleResolutionError(
+            f"anchor '{marker}' not found in API page for '{anchor}'"
+        )
+    fence = re.search(r"```python\n(.*?)\n```", qmd_text[idx:], re.DOTALL)
+    if fence is None:
+        raise TitleResolutionError(
+            f"no python signature block after anchor '{marker}'"
+        )
+    return flatten_python_block(fence.group(1))
+
+
+def _href(file_stem: str, anchor: str) -> str:
+    return f"{API_BASE_URL}/{file_stem}.html#{anchor}"
+
+
+def resolve_title(
+    title: str, api_dir: str | os.PathLike = "api/core"
+) -> tuple[str, str]:
+    """Return ``(href, signature)`` for ``title``; raise if unresolvable."""
+    name = normalize_title(title)
+    anchor = f"shiny.{name}"
+    api_dir = os.fspath(api_dir)
+
+    # 1. Top-level object: its own qmd file.
+    own = os.path.join(api_dir, f"{name}.qmd")
+    if os.path.isfile(own):
+        sig = extract_signature_block(_read(own), anchor)
+        return _href(name, anchor), sig
+
+    # 2. Method: <Class>.<method> lives on the class file with a section anchor.
+    if "." in name:
+        parent = name.rsplit(".", 1)[0]
+        cls = os.path.join(api_dir, f"{parent}.qmd")
+        if os.path.isfile(cls):
+            sig = extract_signature_block(_read(cls), anchor)
+            return _href(parent, anchor), sig
+
+    raise TitleResolutionError(
+        f"title '{title}' -> '{name}': no API page at '{own}' "
+        f"(nor a class file for a method). Add it to SKIP_TITLES if intentional."
+    )
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()

--- a/components/_relevant_functions.py
+++ b/components/_relevant_functions.py
@@ -117,3 +117,75 @@ def resolve_title(
 def _read(path: str) -> str:
     with open(path, encoding="utf-8") as f:
         return f.read()
+
+
+from _qmd import get_qmd_split, write_qmd
+
+_COMPONENT_DIRS = (
+    "components/inputs",
+    "components/outputs",
+    "components/display-messages",
+    "components/layout",
+)
+_LAYOUT_DIRS = ("layouts",)
+
+
+def find_index_qmds() -> list[str]:
+    """Every component + layout ``index.qmd`` (leaf pages)."""
+    out: list[str] = []
+    for base in (*_COMPONENT_DIRS, *_LAYOUT_DIRS):
+        if not os.path.isdir(base):
+            continue
+        for entry in sorted(os.listdir(base)):
+            cdir = os.path.join(base, entry)
+            if not os.path.isdir(cdir) or ".ruff_cache" in cdir:
+                continue
+            qmd = os.path.join(cdir, "index.qmd")
+            if os.path.isfile(qmd):
+                out.append(qmd)
+    return out
+
+
+def resolve_index_qmds(paths: list[str]) -> list[str]:
+    """Map dirs / files / index.qmd paths to their owning ``index.qmd``."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        path = os.path.normpath(path)
+        if os.path.isdir(path):
+            qmd = os.path.join(path, "index.qmd")
+        elif os.path.basename(path) == "index.qmd":
+            qmd = path
+        else:
+            qmd = os.path.join(os.path.dirname(path), "index.qmd")
+        if os.path.isfile(qmd) and qmd not in seen:
+            seen.add(qmd)
+            out.append(qmd)
+    return out
+
+
+def rewrite_relevant_functions(qmd: str, api_dir: str | os.PathLike = "api/core") -> bool:
+    """Rewrite href/signature for every relevant-functions entry in ``qmd``."""
+    meta, body = get_qmd_split(qmd)
+    listing = meta.get("listing")
+    if not listing:
+        return False
+    if isinstance(listing, dict):
+        listing = [listing]
+
+    had_block = False
+    for block in listing:
+        if not (isinstance(block, dict) and block.get("id") == "relevant-functions"):
+            continue
+        had_block = True
+        for item in block.get("contents") or []:
+            title = str(item.get("title", ""))
+            if title in SKIP_TITLES:
+                continue
+            href, signature = resolve_title(title, api_dir=api_dir)
+            item["href"] = href
+            item["signature"] = signature
+
+    if had_block:
+        write_qmd((meta, body), qmd)
+    return had_block

--- a/components/_relevant_functions.py
+++ b/components/_relevant_functions.py
@@ -62,7 +62,8 @@ def flatten_python_block(block: str) -> str:
     joined = re.sub(r"\s+", " ", joined)
     # Remove a space after "(" and before ")", and the trailing comma before ")".
     joined = joined.replace("( ", "(").replace(" )", ")")
-    joined = joined.replace(", )", ")").replace(",)", ")")
+    # Strip only the trailing separator comma before the final ")".
+    joined = re.sub(r",\s*\)$", ")", joined)
     return joined.strip()
 
 

--- a/components/_relevant_functions.py
+++ b/components/_relevant_functions.py
@@ -15,7 +15,15 @@ from __future__ import annotations
 import os
 import re
 
+from _qmd import get_qmd_split, write_qmd
+
 API_BASE_URL = "https://shiny.posit.co/py/api/core"
+
+# Anchor default paths to the repo root (parent of this file's ``components/``
+# dir) so discovery and API-page lookup work regardless of the current working
+# directory -- pytest run from the repo root, the CLI, or ``cd components``.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_API_DIR = os.path.join(_REPO_ROOT, "api", "core")
 
 
 class TitleResolutionError(Exception):
@@ -41,7 +49,17 @@ _CHAT_INSTANCE = {
     "chat.ui()",
 }
 
-SKIP_TITLES: set[str] = _EXTERNAL | _CHAT_INSTANCE
+# Transitional: these resolve once the py-shiny submodule bump lands (see
+# posit-dev/py-shiny-site#404). Until then the pinned submodule has no API page
+# for them, so leave their hand-authored fields untouched instead of erroring.
+# Remove from this set once #404 is merged (card_body gains an api/ page;
+# panel_well's dead link is dropped).
+_PENDING_SUBMODULE_BUMP = {
+    "ui.card_body",
+    "ui.panel_well",
+}
+
+SKIP_TITLES: set[str] = _EXTERNAL | _CHAT_INSTANCE | _PENDING_SUBMODULE_BUMP
 
 
 def normalize_title(title: str) -> str:
@@ -88,7 +106,7 @@ def _href(file_stem: str, anchor: str) -> str:
 
 
 def resolve_title(
-    title: str, api_dir: str | os.PathLike = "api/core"
+    title: str, api_dir: str | os.PathLike = DEFAULT_API_DIR
 ) -> tuple[str, str]:
     """Return ``(href, signature)`` for ``title``; raise if unresolvable."""
     name = normalize_title(title)
@@ -120,15 +138,11 @@ def _read(path: str) -> str:
         return f.read()
 
 
-from _qmd import get_qmd_split, write_qmd
-
-_COMPONENT_DIRS = (
-    "components/inputs",
-    "components/outputs",
-    "components/display-messages",
-    "components/layout",
+_COMPONENT_DIRS = tuple(
+    os.path.join(_REPO_ROOT, "components", d)
+    for d in ("inputs", "outputs", "display-messages", "layout")
 )
-_LAYOUT_DIRS = ("layouts",)
+_LAYOUT_DIRS = (os.path.join(_REPO_ROOT, "layouts"),)
 
 
 def find_index_qmds() -> list[str]:
@@ -165,7 +179,7 @@ def resolve_index_qmds(paths: list[str]) -> list[str]:
     return out
 
 
-def rewrite_relevant_functions(qmd: str, api_dir: str | os.PathLike = "api/core") -> bool:
+def rewrite_relevant_functions(qmd: str, api_dir: str | os.PathLike = DEFAULT_API_DIR) -> bool:
     """Rewrite href/signature for every relevant-functions entry in ``qmd``."""
     meta, body = get_qmd_split(qmd)
     listing = meta.get("listing")

--- a/components/_relevant_functions.py
+++ b/components/_relevant_functions.py
@@ -12,10 +12,13 @@ which renders a different context-manager signature).
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 
 from _qmd import get_qmd_split, write_qmd
+
+lg = logging.getLogger("relevant-functions")
 
 API_BASE_URL = "https://shiny.posit.co/py/api/core"
 
@@ -179,8 +182,19 @@ def resolve_index_qmds(paths: list[str]) -> list[str]:
     return out
 
 
-def rewrite_relevant_functions(qmd: str, api_dir: str | os.PathLike = DEFAULT_API_DIR) -> bool:
-    """Rewrite href/signature for every relevant-functions entry in ``qmd``."""
+def rewrite_relevant_functions(
+    qmd: str,
+    api_dir: str | os.PathLike = DEFAULT_API_DIR,
+    strict: bool = True,
+) -> bool:
+    """Rewrite href/signature for every relevant-functions entry in ``qmd``.
+
+    When ``strict`` (the default), an unresolvable title raises
+    ``TitleResolutionError``. When not strict, the generator "falls forward":
+    an unresolvable title is logged and left as-authored so a single rotted
+    entry never aborts a build/setup run. CI runs strict, so the rot is still
+    required to be fixed before merge.
+    """
     meta, body = get_qmd_split(qmd)
     listing = meta.get("listing")
     if not listing:
@@ -197,7 +211,13 @@ def rewrite_relevant_functions(qmd: str, api_dir: str | os.PathLike = DEFAULT_AP
             title = str(item.get("title", ""))
             if title in SKIP_TITLES:
                 continue
-            href, signature = resolve_title(title, api_dir=api_dir)
+            try:
+                href, signature = resolve_title(title, api_dir=api_dir)
+            except TitleResolutionError as err:
+                if strict:
+                    raise
+                lg.warning(f"{qmd}: leaving unresolvable title as-authored: {err}")
+                continue
             item["href"] = href
             item["signature"] = signature
 

--- a/components/display-messages/modal/index.qmd
+++ b/components/display-messages/modal/index.qmd
@@ -22,17 +22,17 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.modal
-    href: https://shiny.posit.co/py/api/ui.modal.html
+    href: https://shiny.posit.co/py/api/core/ui.modal.html#shiny.ui.modal
     signature: ui.modal(*args, title=None, footer=MISSING, size='m', easy_close=False,
       fade=True, **kwargs)
   - title: ui.modal_show
-    href: https://shiny.posit.co/py/api/ui.modal_show.html
+    href: https://shiny.posit.co/py/api/core/ui.modal_show.html#shiny.ui.modal_show
     signature: ui.modal_show(modal, session=None)
   - title: ui.modal_remove
-    href: https://shiny.posit.co/py/api/ui.modal_remove.html
+    href: https://shiny.posit.co/py/api/core/ui.modal_remove.html#shiny.ui.modal_remove
     signature: ui.modal_remove(session=None)
   - title: ui.modal_button
-    href: https://shiny.posit.co/py/api/ui.modal_button.html
+    href: https://shiny.posit.co/py/api/core/ui.modal_button.html#shiny.ui.modal_button
     signature: ui.modal_button(label, icon=None, **kwargs)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/display-messages/notifications/index.qmd
+++ b/components/display-messages/notifications/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/display-messages/notifications/
   contents:
   - title: ui.notification_show
-    href: https://shiny.posit.co/py/api/ui.notification_show.html
+    href: https://shiny.posit.co/py/api/core/ui.notification_show.html#shiny.ui.notification_show
     signature: ui.notification_show(ui, *, action=None, duration=5, close_button=True,
       id=None, type='default', session=None)
   - title: ui.notification_remove
-    href: https://shiny.posit.co/py/api/ui.notification_remove.html
+    href: https://shiny.posit.co/py/api/core/ui.notification_remove.html#shiny.ui.notification_remove
     signature: ui.notification_remove(id, *, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
@@ -36,11 +36,8 @@ listing:
     dir: components/display-messages/notifications/
   contents:
   - title: Replace/update a notification
-    description: 'Assign a notification an `id` to replace any existing notification
-      with the same `id`. In the example below, a persistant notification is created
-      with `duration=None` and updated each time you click the notification button.
-
-      '
+    description: |
+      Assign a notification an `id` to replace any existing notification with the same `id`. In the example below, a persistant notification is created with `duration=None` and updated each time you click the notification button.
     apps:
     - title: Preview
       file: app-variation-replace-update-a-notification-core.py

--- a/components/display-messages/progress-bar/index.qmd
+++ b/components/display-messages/progress-bar/index.qmd
@@ -24,17 +24,17 @@ listing:
     dir: components/display-messages/progress-bar/
   contents:
   - title: ui.Progress
-    href: https://shiny.posit.co/py/api/ui.Progress.html
-    signature: ui.Progress(self, min=0, max=1, session=None)
+    href: https://shiny.posit.co/py/api/core/ui.Progress.html#shiny.ui.Progress
+    signature: ui.Progress(min=0, max=1, session=None)
   - title: ui.Progress.close
-    href: https://shiny.posit.co/py/api/ui.Progress.html
-    signature: ui.Progress.close(self)
+    href: https://shiny.posit.co/py/api/core/ui.Progress.html#shiny.ui.Progress.close
+    signature: ui.Progress.close()
   - title: ui.Progress.inc
-    href: https://shiny.posit.co/py/api/ui.Progress.html
-    signature: ui.Progress.inc(self, amount=0.1, message=None, detail=None)
+    href: https://shiny.posit.co/py/api/core/ui.Progress.html#shiny.ui.Progress.inc
+    signature: ui.Progress.inc(amount=0.1, message=None, detail=None)
   - title: ui.Progress.set
-    href: https://shiny.posit.co/py/api/ui.Progress.html
-    signature: ui.Progress.set(self, value=None, message=None, detail=None)
+    href: https://shiny.posit.co/py/api/core/ui.Progress.html#shiny.ui.Progress.set
+    signature: ui.Progress.set(value=None, message=None, detail=None)
 ---
 
 :::{#example}

--- a/components/display-messages/tooltips/index.qmd
+++ b/components/display-messages/tooltips/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/display-messages/tooltips/
   contents:
   - title: ui.tooltip
-    href: https://shiny.posit.co/py/api/ui.tooltip.html
+    href: https://shiny.posit.co/py/api/core/ui.tooltip.html#shiny.ui.tooltip
     signature: ui.tooltip(trigger, *args, id=None, placement='auto', options=None,
       **kwargs)
   - title: ui.update_tooltip
-    href: https://shiny.posit.co/py/api/ui.update_tooltip.html
+    href: https://shiny.posit.co/py/api/core/ui.update_tooltip.html#shiny.ui.update_tooltip
     signature: ui.update_tooltip(id, *args, show=None, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/inputs/action-button/index.qmd
+++ b/components/inputs/action-button/index.qmd
@@ -23,13 +23,14 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_action_button
-    href: https://shiny.posit.co/py/api/ui.input_action_button.html
-    signature: ui.input_action_button(id, label, *, icon=None, width=None, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.input_action_button.html#shiny.ui.input_action_button
+    signature: ui.input_action_button(id, label, *, icon=None, width=None, disabled=False,
+      **kwargs)
   - title: reactive.event
-    href: https://shiny.posit.co/py/api/reactive.event.html
+    href: https://shiny.posit.co/py/api/core/reactive.event.html#shiny.reactive.event
     signature: reactive.event(*args, ignore_none=True, ignore_init=False)
   - title: ui.update_action_button
-    href: https://shiny.posit.co/py/api/ui.update_action_button.html
+    href: https://shiny.posit.co/py/api/core/ui.update_action_button.html#shiny.ui.update_action_button
     signature: ui.update_action_button(id, *, label=None, icon=None, disabled=None,
       session=None)
 - id: kitchen-sink

--- a/components/inputs/action-link/index.qmd
+++ b/components/inputs/action-link/index.qmd
@@ -23,13 +23,13 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_action_link
-    href: https://shiny.posit.co/py/api/ui.input_action_link.html
+    href: https://shiny.posit.co/py/api/core/ui.input_action_link.html#shiny.ui.input_action_link
     signature: ui.input_action_link(id, label, *, icon=None, **kwargs)
   - title: reactive.event
-    href: https://shiny.posit.co/py/api/reactive.event.html
+    href: https://shiny.posit.co/py/api/core/reactive.event.html#shiny.reactive.event
     signature: reactive.event(*args, ignore_none=True, ignore_init=False)
   - title: ui.update_action_link
-    href: https://shiny.posit.co/py/api/ui.update_action_link.html
+    href: https://shiny.posit.co/py/api/core/ui.update_action_link.html#shiny.ui.update_action_link
     signature: ui.update_action_link(id, *, label=None, icon=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs

--- a/components/inputs/checkbox-group/index.qmd
+++ b/components/inputs/checkbox-group/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_checkbox_group
-    href: https://shiny.posit.co/py/api/ui.input_checkbox_group.html
+    href: https://shiny.posit.co/py/api/core/ui.input_checkbox_group.html#shiny.ui.input_checkbox_group
     signature: ui.input_checkbox_group(id, label, choices, *, selected=None, inline=False,
       width=None)
   - title: ui.update_checkbox_group
-    href: https://shiny.posit.co/py/api/ui.update_checkbox_group.html
+    href: https://shiny.posit.co/py/api/core/ui.update_checkbox_group.html#shiny.ui.update_checkbox_group
     signature: ui.update_checkbox_group(id, *, label=None, choices=None, selected=None,
       inline=False, session=None)
 - id: kitchen-sink

--- a/components/inputs/checkbox/index.qmd
+++ b/components/inputs/checkbox/index.qmd
@@ -23,10 +23,10 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_checkbox()
-    href: https://shiny.posit.co/py/api/ui.input_checkbox.html
+    href: https://shiny.posit.co/py/api/core/ui.input_checkbox.html#shiny.ui.input_checkbox
     signature: ui.input_checkbox(id, label, value=False, *, width=None)
   - title: ui.update_checkbox
-    href: https://shiny.posit.co/py/api/ui.update_checkbox.html
+    href: https://shiny.posit.co/py/api/core/ui.update_checkbox.html#shiny.ui.update_checkbox
     signature: ui.update_checkbox(id, *, label=None, value=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs

--- a/components/inputs/dark-mode/index.qmd
+++ b/components/inputs/dark-mode/index.qmd
@@ -23,10 +23,10 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_dark_mode
-    href: https://shiny.posit.co/py/api/ui.input_dark_mode.html
+    href: https://shiny.posit.co/py/api/core/ui.input_dark_mode.html#shiny.ui.input_dark_mode
     signature: ui.input_dark_mode(id=None, mode=None, **kwargs)
   - title: ui.update_dark_mode
-    href: https://shiny.posit.co/py/api/ui.update_dark_mode.html
+    href: https://shiny.posit.co/py/api/core/ui.update_dark_mode.html#shiny.ui.update_dark_mode
     signature: ui.update_dark_mode(mode, *, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
@@ -34,18 +34,13 @@ listing:
     dir: components/inputs/dark-mode/
   contents:
   - title: Dark mode switch in a navbar
-    description: 'To add a dark mode switch to a navbar, use `ui.page_navbar()` to
-      create a page with a navbar, and `ui.nav_spacer()` to push the dark mode switch
-      to the right. Place the `ui.input_dark_mode()` element within a `ui.nav_control()`
-      element, to add the control to the navbar without creating a corresponding panel.
-
-      '
+    description: |
+      To add a dark mode switch to a navbar, use `ui.page_navbar()` to create a page with a navbar, and `ui.nav_spacer()` to push the dark mode switch to the right. Place the `ui.input_dark_mode()` element within a `ui.nav_control()` element, to add the control to the navbar without creating a corresponding panel.
     apps:
     - title: Preview
       file: app-variation-dark-mode-navbar-core.py
-      attrs: '.scale-iframe style="--scale-factor: 0.8;"
-
-        '
+      attrs: |
+        .scale-iframe style="--scale-factor: 0.8;"
     - title: Express
       file: app-variation-dark-mode-navbar-express.py
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAZwAsBLCXLOAD3QM4rVsk4x0pBhWQBXTgB0IyhTigBzOAH1S6CqwAUFThQA2cALyKwAESgMA1shikAJnDYB3U8XbiIZGgANwAjBxsiOk4zMyhQi0sAFQY5OCJON2swdE04GwBKZVVOLBDtVlziOAZDAuRkAGJkAB4W5R8KfzVyskomMzqUJtb2wIb5Uu50OQptNwdHbVcPOobmtuVCVApcdAQUMCp+CjAAXwBdIA

--- a/components/inputs/date-range-selector/index.qmd
+++ b/components/inputs/date-range-selector/index.qmd
@@ -23,12 +23,12 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_date_range
-    href: https://shiny.posit.co/py/api/ui.input_date_range.html
+    href: https://shiny.posit.co/py/api/core/ui.input_date_range.html#shiny.ui.input_date_range
     signature: ui.input_date_range(id, label, *, start=None, end=None, min=None, max=None,
       format='yyyy-mm-dd', startview='month', weekstart=0, language='en', separator='
       to ', width=None, autoclose=True)
   - title: ui.update_date_range
-    href: https://shiny.posit.co/py/api/ui.update_date_range.html
+    href: https://shiny.posit.co/py/api/core/ui.update_date_range.html#shiny.ui.update_date_range
     signature: ui.update_date_range(id, *, label=None, start=None, end=None, min=None,
       max=None, session=None)
 - id: kitchen-sink

--- a/components/inputs/date-selector/index.qmd
+++ b/components/inputs/date-selector/index.qmd
@@ -23,12 +23,12 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_date
-    href: https://shiny.posit.co/py/api/ui.input_date.html
+    href: https://shiny.posit.co/py/api/core/ui.input_date.html#shiny.ui.input_date
     signature: ui.input_date(id, label, *, value=None, min=None, max=None, format='yyyy-mm-dd',
       startview='month', weekstart=0, language='en', width=None, autoclose=True, datesdisabled=None,
       daysofweekdisabled=None)
   - title: ui.update_date
-    href: https://shiny.posit.co/py/api/ui.update_date.html
+    href: https://shiny.posit.co/py/api/core/ui.update_date.html#shiny.ui.update_date
     signature: ui.update_date(id, *, label=None, value=None, min=None, max=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs

--- a/components/inputs/file/index.qmd
+++ b/components/inputs/file/index.qmd
@@ -23,12 +23,12 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_file
-    href: https://shiny.posit.co/py/api/core/ui.input_file.html
+    href: https://shiny.posit.co/py/api/core/ui.input_file.html#shiny.ui.input_file
     signature: ui.input_file(id, label, *, multiple=False, accept=None, width=None,
       button_label='Browse...', placeholder='No file selected', capture=None)
   - title: express.ui.input_file
-    href: https://shiny.posit.co/py/api/express/express.ui.input_file.html
-    signature: express.ui.input_file(id, label, *, multiple=False, accept=None, width=None,
+    href: https://shiny.posit.co/py/api/core/ui.input_file.html#shiny.ui.input_file
+    signature: ui.input_file(id, label, *, multiple=False, accept=None, width=None,
       button_label='Browse...', placeholder='No file selected', capture=None)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/inputs/numeric-input/index.qmd
+++ b/components/inputs/numeric-input/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_numeric
-    href: https://shiny.posit.co/py/api/ui.input_numeric.html
+    href: https://shiny.posit.co/py/api/core/ui.input_numeric.html#shiny.ui.input_numeric
     signature: ui.input_numeric(id, label, value, *, min=None, max=None, step=None,
-      width=None)
+      width=None, update_on='change')
   - title: ui.update_numeric
-    href: https://shiny.posit.co/py/api/ui.update_numeric.html
+    href: https://shiny.posit.co/py/api/core/ui.update_numeric.html#shiny.ui.update_numeric
     signature: ui.update_numeric(id, *, label=None, value=None, min=None, max=None,
       step=None, session=None)
 - id: kitchen-sink

--- a/components/inputs/password-field/index.qmd
+++ b/components/inputs/password-field/index.qmd
@@ -23,8 +23,9 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_password
-    href: https://shiny.posit.co/py/api/ui.input_password.html
-    signature: ui.input_password(id, label, value='', *, width=None, placeholder=None)
+    href: https://shiny.posit.co/py/api/core/ui.input_password.html#shiny.ui.input_password
+    signature: ui.input_password(id, label, value='', *, width=None, placeholder=None,
+      update_on='change')
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs
   contents:

--- a/components/inputs/radio-buttons/index.qmd
+++ b/components/inputs/radio-buttons/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_radio_buttons
-    href: https://shiny.posit.co/py/api/ui.input_radio_buttons.html
+    href: https://shiny.posit.co/py/api/core/ui.input_radio_buttons.html#shiny.ui.input_radio_buttons
     signature: ui.input_radio_buttons(id, label, choices, *, selected=None, inline=False,
       width=None)
   - title: ui.update_radio_buttons
-    href: https://shiny.posit.co/py/api/ui.update_radio_buttons.html
+    href: https://shiny.posit.co/py/api/core/ui.update_radio_buttons.html#shiny.ui.update_radio_buttons
     signature: ui.update_radio_buttons(id, *, label=None, choices=None, selected=None,
       inline=False, session=None)
 - id: kitchen-sink

--- a/components/inputs/select-multiple/index.qmd
+++ b/components/inputs/select-multiple/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_select
-    href: https://shiny.posit.co/py/api/ui.input_select.html
+    href: https://shiny.posit.co/py/api/core/ui.input_select.html#shiny.ui.input_select
     signature: ui.input_select(id, label, choices, *, selected=None, multiple=False,
-      selectize=False, width=None, size=None)
+      selectize=DEPRECATED, width=None, size=None, remove_button=DEPRECATED, options=DEPRECATED)
   - title: ui.update_select
-    href: https://shiny.posit.co/py/api/ui.update_select.html
+    href: https://shiny.posit.co/py/api/core/ui.update_select.html#shiny.ui.update_select
     signature: ui.update_select(id, *, label=None, choices=None, selected=None, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/inputs/select-single/index.qmd
+++ b/components/inputs/select-single/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_select
-    href: https://shiny.posit.co/py/api/ui.input_select.html
+    href: https://shiny.posit.co/py/api/core/ui.input_select.html#shiny.ui.input_select
     signature: ui.input_select(id, label, choices, *, selected=None, multiple=False,
-      selectize=False, width=None, size=None)
+      selectize=DEPRECATED, width=None, size=None, remove_button=DEPRECATED, options=DEPRECATED)
   - title: ui.update_select
-    href: https://shiny.posit.co/py/api/ui.update_select.html
+    href: https://shiny.posit.co/py/api/core/ui.update_select.html#shiny.ui.update_select
     signature: ui.update_select(id, *, label=None, choices=None, selected=None, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/inputs/selectize-multiple/index.qmd
+++ b/components/inputs/selectize-multiple/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_selectize
-    href: https://shiny.posit.co/py/api/ui.input_selectize.html
+    href: https://shiny.posit.co/py/api/core/ui.input_selectize.html#shiny.ui.input_selectize
     signature: ui.input_selectize(id, label, choices, *, selected=None, multiple=False,
-      width=None)
+      width=None, remove_button=None, options=None)
   - title: ui.update_selectize
-    href: https://shiny.posit.co/py/api/ui.update_selectize.html
+    href: https://shiny.posit.co/py/api/core/ui.update_selectize.html#shiny.ui.update_selectize
     signature: ui.update_selectize(id, *, label=None, choices=None, selected=None,
       options=None, server=False, session=None)
 - id: variations

--- a/components/inputs/selectize-single/index.qmd
+++ b/components/inputs/selectize-single/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_selectize
-    href: https://shiny.posit.co/py/api/ui.input_selectize.html
+    href: https://shiny.posit.co/py/api/core/ui.input_selectize.html#shiny.ui.input_selectize
     signature: ui.input_selectize(id, label, choices, *, selected=None, multiple=False,
-      width=None)
+      width=None, remove_button=None, options=None)
   - title: ui.update_selectize
-    href: https://shiny.posit.co/py/api/ui.update_selectize.html
+    href: https://shiny.posit.co/py/api/core/ui.update_selectize.html#shiny.ui.update_selectize
     signature: ui.update_selectize(id, *, label=None, choices=None, selected=None,
       options=None, server=False, session=None)
 - id: variations

--- a/components/inputs/slider-range/index.qmd
+++ b/components/inputs/slider-range/index.qmd
@@ -23,22 +23,22 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_slider
-    href: https://shiny.posit.co/py/api/ui.input_slider.html
+    href: https://shiny.posit.co/py/api/core/ui.input_slider.html#shiny.ui.input_slider
     signature: ui.input_slider(id, label, min, max, value, *, step=None, ticks=False,
       animate=False, width=None, sep=',', pre=None, post=None, time_format=None, timezone=None,
       drag_range=True)
   - title: ui.output_data_frame
-    href: https://shiny.posit.co/py/api/ui.output_data_frame.html
+    href: https://shiny.posit.co/py/api/core/ui.output_data_frame.html#shiny.ui.output_data_frame
     signature: ui.output_data_frame(id)
   - title: render.data_frame
-    href: https://shiny.posit.co/py/api/render.data_frame.html
-    signature: render.data_frame(fn=None)
+    href: https://shiny.posit.co/py/api/core/render.data_frame.html#shiny.render.data_frame
+    signature: render.data_frame(fn)
   - title: render.DataTable
-    href: https://shiny.posit.co/py/api/render.DataTable.html
-    signature: render.DataTable(self, data, *, width='fit-content', height='500px',
-      summary=True, filters=False, row_selection_mode='none')
+    href: https://shiny.posit.co/py/api/core/render.DataTable.html#shiny.render.DataTable
+    signature: render.DataTable(data, *, width='fit-content', height='500px', summary=True,
+      filters=False, editable=False, selection_mode='none', styles=None, row_selection_mode='deprecated')
   - title: ui.update_slider
-    href: https://shiny.posit.co/py/api/ui.update_slider.html
+    href: https://shiny.posit.co/py/api/core/ui.update_slider.html#shiny.ui.update_slider
     signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None,
       step=None, time_format=None, timezone=None, session=None)
 - id: kitchen-sink

--- a/components/inputs/slider/index.qmd
+++ b/components/inputs/slider/index.qmd
@@ -23,12 +23,12 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_slider
-    href: https://shiny.posit.co/py/api/ui.input_slider.html
+    href: https://shiny.posit.co/py/api/core/ui.input_slider.html#shiny.ui.input_slider
     signature: ui.input_slider(id, label, min, max, value, *, step=None, ticks=False,
       animate=False, width=None, sep=',', pre=None, post=None, time_format=None, timezone=None,
       drag_range=True)
   - title: ui.update_slider
-    href: https://shiny.posit.co/py/api/ui.update_slider.html
+    href: https://shiny.posit.co/py/api/core/ui.update_slider.html#shiny.ui.update_slider
     signature: ui.update_slider(id, *, label=None, value=None, min=None, max=None,
       step=None, time_format=None, timezone=None, session=None)
 - id: kitchen-sink

--- a/components/inputs/switch/index.qmd
+++ b/components/inputs/switch/index.qmd
@@ -23,10 +23,10 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_switch
-    href: https://shiny.posit.co/py/api/ui.input_switch.html
+    href: https://shiny.posit.co/py/api/core/ui.input_switch.html#shiny.ui.input_switch
     signature: ui.input_switch(id, label, value=False, *, width=None)
   - title: ui.update_switch
-    href: https://shiny.posit.co/py/api/ui.update_switch.html
+    href: https://shiny.posit.co/py/api/core/ui.update_switch.html#shiny.ui.update_switch
     signature: ui.update_switch(id, *, label=None, value=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs

--- a/components/inputs/text-area/index.qmd
+++ b/components/inputs/text-area/index.qmd
@@ -23,12 +23,12 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_text_area
-    href: https://shiny.posit.co/py/api/ui.input_text_area.html
+    href: https://shiny.posit.co/py/api/core/ui.input_text_area.html#shiny.ui.input_text_area
     signature: ui.input_text_area(id, label, value='', *, width=None, height=None,
       cols=None, rows=None, placeholder=None, resize=None, autoresize=False, autocomplete=None,
-      spellcheck=None)
+      spellcheck=None, update_on='change')
   - title: ui.update_text_area
-    href: https://shiny.posit.co/py/api/ui.update_text_area.html
+    href: https://shiny.posit.co/py/api/core/ui.update_text_area.html#shiny.ui.update_text_area
     signature: ui.update_text_area(id, *, label=None, value=None, placeholder=None,
       session=None)
 - id: kitchen-sink

--- a/components/inputs/text-box/index.qmd
+++ b/components/inputs/text-box/index.qmd
@@ -23,11 +23,11 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.input_text
-    href: https://shiny.posit.co/py/api/ui.input_text.html
+    href: https://shiny.posit.co/py/api/core/ui.input_text.html#shiny.ui.input_text
     signature: ui.input_text(id, label, value='', *, width=None, placeholder=None,
-      autocomplete='off', spellcheck=None)
+      autocomplete='off', spellcheck=None, update_on='change')
   - title: ui.update_text
-    href: https://shiny.posit.co/py/api/ui.update_text.html
+    href: https://shiny.posit.co/py/api/core/ui.update_text.html#shiny.ui.update_text
     signature: ui.update_text(id, *, label=None, value=None, placeholder=None, session=None)
 - id: kitchen-sink
   template: ../../_partials/components-detail-kitchen-sink.ejs

--- a/components/inputs/toolbar-button/index.qmd
+++ b/components/inputs/toolbar-button/index.qmd
@@ -23,16 +23,16 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.toolbar_input_button
-    href: https://shiny.posit.co/py/api/ui.toolbar_input_button.html
+    href: https://shiny.posit.co/py/api/core/ui.toolbar_input_button.html#shiny.ui.toolbar_input_button
     signature: ui.toolbar_input_button(id, label, *, icon=None, show_label=MISSING,
       tooltip=MISSING, disabled=False, border=False, **kwargs)
   - title: ui.update_toolbar_input_button
-    href: https://shiny.posit.co/py/api/ui.update_toolbar_input_button.html
+    href: https://shiny.posit.co/py/api/core/ui.update_toolbar_input_button.html#shiny.ui.update_toolbar_input_button
     signature: ui.update_toolbar_input_button(id, *, label=None, show_label=None,
       icon=None, disabled=None, session=None)
   - title: ui.toolbar
-    href: https://shiny.posit.co/py/api/ui.toolbar.html
-    signature: ui.toolbar(*args, align="right", gap=None, width=None)
+    href: https://shiny.posit.co/py/api/core/ui.toolbar.html#shiny.ui.toolbar
+    signature: ui.toolbar(*args, align='right', gap=None, width=None)
 - id: variations-update-buttons
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/inputs/toolbar-select/index.qmd
+++ b/components/inputs/toolbar-select/index.qmd
@@ -23,16 +23,16 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.toolbar_input_select
-    href: https://shiny.posit.co/py/api/ui.toolbar_input_select.html
+    href: https://shiny.posit.co/py/api/core/ui.toolbar_input_select.html#shiny.ui.toolbar_input_select
     signature: ui.toolbar_input_select(id, label, choices, *, selected=None, icon=None,
       show_label=False, tooltip=MISSING, **kwargs)
   - title: ui.update_toolbar_input_select
-    href: https://shiny.posit.co/py/api/ui.update_toolbar_input_select.html
+    href: https://shiny.posit.co/py/api/core/ui.update_toolbar_input_select.html#shiny.ui.update_toolbar_input_select
     signature: ui.update_toolbar_input_select(id, *, label=None, show_label=None,
       choices=None, selected=None, icon=None, session=None)
   - title: ui.toolbar
-    href: https://shiny.posit.co/py/api/ui.toolbar.html
-    signature: ui.toolbar(*args, align="right", gap=None, width=None)
+    href: https://shiny.posit.co/py/api/core/ui.toolbar.html#shiny.ui.toolbar
+    signature: ui.toolbar(*args, align='right', gap=None, width=None)
 - id: variations-updating
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/layout/accordion/index.qmd
+++ b/components/layout/accordion/index.qmd
@@ -23,25 +23,25 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.accordion
-    href: https://shiny.posit.co/py/api/ui.accordion.html
+    href: https://shiny.posit.co/py/api/core/ui.accordion.html#shiny.ui.accordion
     signature: ui.accordion(*args, id=None, open=None, multiple=True, class_=None,
       width=None, height=None, **kwargs)
   - title: ui.accordion_panel
-    href: https://shiny.posit.co/py/api/ui.accordion_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.accordion_panel.html#shiny.ui.accordion_panel
     signature: ui.accordion_panel(title, *args, value=MISSING, icon=None, **kwargs)
   - title: ui.update_accordion
-    href: https://shiny.posit.co/py/api/ui.update_accordion.html
+    href: https://shiny.posit.co/py/api/core/ui.update_accordion.html#shiny.ui.update_accordion
     signature: ui.update_accordion(id, *, show, session=None)
   - title: ui.update_accordion_panel
-    href: https://shiny.posit.co/py/api/ui.update_accordion_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.update_accordion_panel.html#shiny.ui.update_accordion_panel
     signature: ui.update_accordion_panel(id, target, *body, title=MISSING, value=MISSING,
       icon=MISSING, show=None, session=None)
   - title: ui.insert_accordion_panel
-    href: https://shiny.posit.co/py/api/ui.insert_accordion_panel.html
-    signature: ui.insert_accordion_panel(id, panel, target=None, position="after",
+    href: https://shiny.posit.co/py/api/core/ui.insert_accordion_panel.html#shiny.ui.insert_accordion_panel
+    signature: ui.insert_accordion_panel(id, panel, target=None, position='after',
       session=None)
   - title: ui.remove_accordion_panel
-    href: https://shiny.posit.co/py/api/ui.remove_accordion_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.remove_accordion_panel.html#shiny.ui.remove_accordion_panel
     signature: ui.remove_accordion_panel(id, target, session=None)
 - id: variation-update-panel
   template: ../../_partials/components-variations.ejs

--- a/components/layout/cards/index.qmd
+++ b/components/layout/cards/index.qmd
@@ -23,19 +23,19 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.card
-    href: https://shiny.posit.co/py/api/ui.card.html
+    href: https://shiny.posit.co/py/api/core/ui.card.html#shiny.ui.card
     signature: ui.card(*args, full_screen=False, height=None, max_height=None, min_height=None,
-      fill=True, class_=None, **kwargs)
+      fill=True, class_=None, id=None, **kwargs)
   - title: ui.card_header
-    href: https://shiny.posit.co/py/api/ui.card_header.html
-    signature: ui.card_header(*args, container=..., **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.card_header.html#shiny.ui.card_header
+    signature: ui.card_header(*args, container=tags.div, **kwargs)
   - title: ui.card_body
     href: https://shiny.posit.co/py/api/ui.card_body.html
     signature: ui.card_body(*args, fillable=True, min_height=None, max_height=None,
       max_height_full_screen=None, height=None, padding=None, gap=None, fill=True,
       class_=None, **kwargs)
   - title: ui.card_footer
-    href: https://shiny.posit.co/py/api/ui.card_footer.html
+    href: https://shiny.posit.co/py/api/core/ui.card_footer.html#shiny.ui.card_footer
     signature: ui.card_footer(*args, **kwargs)
 - id: variation-toolbar-header-footer
   template: ../../_partials/components-variations.ejs

--- a/components/layout/toolbar/index.qmd
+++ b/components/layout/toolbar/index.qmd
@@ -23,21 +23,21 @@ listing:
   template: ../../_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.toolbar
-    href: https://shiny.posit.co/py/api/ui.toolbar.html
-    signature: ui.toolbar(*args, align="right", gap=None, width=None)
+    href: https://shiny.posit.co/py/api/core/ui.toolbar.html#shiny.ui.toolbar
+    signature: ui.toolbar(*args, align='right', gap=None, width=None)
   - title: ui.toolbar_input_button
-    href: https://shiny.posit.co/py/api/ui.toolbar_input_button.html
+    href: https://shiny.posit.co/py/api/core/ui.toolbar_input_button.html#shiny.ui.toolbar_input_button
     signature: ui.toolbar_input_button(id, label, *, icon=None, show_label=MISSING,
       tooltip=MISSING, disabled=False, border=False, **kwargs)
   - title: ui.toolbar_input_select
-    href: https://shiny.posit.co/py/api/ui.toolbar_input_select.html
+    href: https://shiny.posit.co/py/api/core/ui.toolbar_input_select.html#shiny.ui.toolbar_input_select
     signature: ui.toolbar_input_select(id, label, choices, *, selected=None, icon=None,
       show_label=False, tooltip=MISSING, **kwargs)
   - title: ui.toolbar_divider
-    href: https://shiny.posit.co/py/api/ui.toolbar_divider.html
+    href: https://shiny.posit.co/py/api/core/ui.toolbar_divider.html#shiny.ui.toolbar_divider
     signature: ui.toolbar_divider(width=None, gap=None)
   - title: ui.toolbar_spacer
-    href: https://shiny.posit.co/py/api/ui.toolbar_spacer.html
+    href: https://shiny.posit.co/py/api/core/ui.toolbar_spacer.html#shiny.ui.toolbar_spacer
     signature: ui.toolbar_spacer()
 - id: variation-with-spacer
   template: ../../_partials/components-variations.ejs

--- a/components/outputs/data-grid/index.qmd
+++ b/components/outputs/data-grid/index.qmd
@@ -30,15 +30,15 @@ listing:
     dir: components/outputs/data-grid/
   contents:
   - title: ui.output_data_frame
-    href: https://shiny.posit.co/py/api/ui.output_data_frame.html
+    href: https://shiny.posit.co/py/api/core/ui.output_data_frame.html#shiny.ui.output_data_frame
     signature: ui.output_data_frame(id)
   - title: '@render.data_frame'
-    href: https://shiny.posit.co/py/api/render.data_frame.html
-    signature: render.data_frame(fn=None)
+    href: https://shiny.posit.co/py/api/core/render.data_frame.html#shiny.render.data_frame
+    signature: render.data_frame(fn)
   - title: render.DataGrid
-    href: https://shiny.posit.co/py/api/render.DataGrid.html
-    signature: render.DataGrid(self, data, *, width='fit-content', height='500px',
-      summary=True, filters=False, row_selection_mode='none')
+    href: https://shiny.posit.co/py/api/core/render.DataGrid.html#shiny.render.DataGrid
+    signature: render.DataGrid(data, *, width='fit-content', height=None, summary=True,
+      filters=False, editable=False, selection_mode='none', styles=None, row_selection_mode='deprecated')
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:
@@ -138,15 +138,9 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZdKAG3gfWoHMBXAJYQAzskEx0pBhWTtSUACYB9HhAHCRAHQiNmyEQAthucZOmyAgpiINqiuAyJCdOtRtHIAvHIUr3QqIAFACUrtCYykLeyEI4ULxwynTsQopBOshZsYJYhgBMGWAAChxcyMV8gdpgIQSZ2XGk-BToLcqKUBRQyQywcEUBmh10WrX1EGEQ4Q50Bo4Abo5Bwm0URM2tLUQicCIiguQhiA1ZAAJ2EA4MWJ3dvf2nyLOsVcOKdKEnENm-yHYUfgMH6Xa5YAAiXSgAHEGIJ0kNREQAO7wiiGLxjADMAAYcegAB5jIiGOCCXiGCiYsD5ACs+KJtSyAGJkAAeNnhHQYdAxazoII8qKCHaLRxTQioCi4Hi0MBUAkUMAAXwAukA
       height: 350
   - title: Styling
-    description: 'Set `styles` in `render.DataGrid()` to a customize the table display.
-      `styles` can take a list of dictionaries where each dictionary represents a
-      style to be applied to the table (and thus should have at least a `style` (or
-      `class`) key to apply CSS styles or classes to the relevant cells). To scope
-      the styling to particular cells, use the `rows` and `cols` keys (with 0-based
-      indexing).
-
-      Note that if both `rows` and `cols` are specified, the style will be applied
-      only to the intersection of the specified rows and columns.'
+    description: |-
+      Set `styles` in `render.DataGrid()` to a customize the table display. `styles` can take a list of dictionaries where each dictionary represents a style to be applied to the table (and thus should have at least a `style` (or `class`) key to apply CSS styles or classes to the relevant cells). To scope the styling to particular cells, use the `rows` and `cols` keys (with 0-based indexing).
+      Note that if both `rows` and `cols` are specified, the style will be applied only to the intersection of the specified rows and columns.
     apps:
     - title: Preview
       file: app-variation-styles-core.py
@@ -160,16 +154,8 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQEsZ1SAnC5dKCAEygGdk+7LgB0IAM2akY7KABt4zdNQDmAVzoR+DJq2SzSULgH0lENRt6iJU5LwAWG3Mm0s2AQUxFm1LnGZF1UVFTc01kAF49A2MQ9U0ACgBKIOhMI3UI5HUcKGU4IzFZdS540WRyrLosOwAmUrAABTkFZAaVOMswRIIyiuzSVQp0QaMeCigC5lg4etiLUbFhLp6IZIgU3zFbPwA3P3iNYYoiAaHBol44Xl46ckTEXvKAAW9uPywxiYlpx+RN9na8y4YiSDwgFQhyG8FFUzHBr18zCwABEoOMAOLMOglX6QipzTRYOj6YjAYAABiIAEYiDVyZTkHSacgAMz0ohsqkAXSIiB5uLxtgouFkV3CwHKAGJkAAeGUCwUVaUAYWoVGYyAodjgmrgAA82KQtnAoMQ7MhiHBZLJkPFVDczMgAEKkUgUXgUKboLIUYl0YUW2R8XiJZDSuUKxXIEBS2Xy8FRxNLYhB65LFBLKgGgC0lsofiWRDDccjioAvkXw-HE3jpS7ZFxNdrkGI6MwPRbSEUYOCq6XBTHixGEzXBcmu50UBSebHh6PFUsPSK4Ono0sxOQKNmAO5wOjKOwUVdLABGXZEYArs+r8-KV6HN9v0oAEvu7LI32wtTqCZ39O2H37PEQCAqMlkkbdJ2QClqRnQCR1vCpx1kKDp0rEsEMQ5BF2FUVVxAsAT1NABrZRJFUbhcy7FhjzASUxDELgiMWS90LnRD7z7TCa0HLisIhcDSEg1dgBqDk4L4-jymQ1DyQkjCpOksAlzw2gCKI4hSPIyiyH-WjJRPKkuAANhMpZOIUji2MfedeMsqTBOE2hgAAFiIABWeT2IcsBdNkrybKwnDl3w08SLIgYdOo5h9JMqAAE4xBqczrNAiELO8qMAsjNYUgwb1Ig8dB4ny9I6AuXY-DWQhUGFJRaDALMKEvLkgA
       height: 350
   - title: Update Filters
-    description: 'The data frame filters can be programmatically updated using the
-      `.update_filter()` method. It takes a list of column filters to apply to the
-      data frame. Each column filter is a dictionary with the following keys: `col`
-      and `value`. The `col` key is the column index to filter on, and the `value`
-      key is the value to filter for. The `value` key can be a single value for string
-      columns or a list of values to filter for numeric columns. Note, to not set
-      a minimum or maximum value for a numeric column, you can provide a `None` value.
-      To reset filters, provide `None` for the filters (`.update_filter(None)`).
-
-      '
+    description: |
+      The data frame filters can be programmatically updated using the `.update_filter()` method. It takes a list of column filters to apply to the data frame. Each column filter is a dictionary with the following keys: `col` and `value`. The `col` key is the column index to filter on, and the `value` key is the value to filter for. The `value` key can be a single value for string columns or a list of values to filter for numeric columns. Note, to not set a minimum or maximum value for a numeric column, you can provide a `None` value. To reset filters, provide `None` for the filters (`.update_filter(None)`).
     apps:
     - title: Preview
       file: app-variation-update-filter-core.py
@@ -183,14 +169,8 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZdKAG3gfWoHMBXAJYQAzskEx0pBhWTtSUACYB9HhAHCRAHQiNmyEQAthucZOmyAgpiIM4UYhUEA3OLeqK4DIkJ061GqLIALxyCioBQqIAFACUftCYykIhyEI4ULxwynTsQorROsjFaYJYhgBMhWAAChxcyDV8UdpgsQRFJenC6PwUyg5O5MoARn0U5NX86IpQVDmC7FQMrURaYACqM3NwyHSLy63tncXdEL39g4LDYxQTENV2InD9+0teq8jrAEpwz7JvQ7rY4QEqlcoAVmqAGF+Aw7JQ9gcPih1kQQOtiOwoCJWqiwOgKABaCrrAC+ILB6VIfQuyjInmqkU0C3eDGBHVBXTKNIodNmFCgOQYsDgTOaLMUdA5OniEASnjoBi8rgY0R6fSIvIuRGeuOuEFiiASYIAAgjPAwsAy4CdkIrWBLRKzlnFjVywcU7BQ4aDmc6pVhAV44sUAMTIAA8kZNJXNHi8WAFQsYortDv9ImUUrddrB3t9yAtiYAInMoABxBiCAqZojBlbBAAqDH4cFi4ajMflHuQ8auriwcDodDgjjt-ccLjgQ9clHV5z6WGmAuyDZEcrBONwEGI9uHyGUud7W4A7lBBLJM9m6MvtvMG9FO9G857isBn9239+ShGAMovKwUAyIIHDIDAczEIYyARi+J4-iUGJgGQ7DrCgAAMaxgM4HBtmhXxgBW1DkkQMFdq+CFkQBsgwMIyA4XkuywV+lGekhKH4RUWEMXhtDRBCmHIAAcuQ7ZkqRzEUQh-6ARBAAe9G4Ux5HwZR7GkKhtAAMzcUp+HRCJEBuMgACMADssTiZ+Uk-jJsgiuoylwaxbGYhp+EACy6Yx+kVBUgl+RClkSSpLkALohc534dmRcETnYA4zsOo7jr2k5OIOcBzhQC4XFgTwvC6HybiU267vuSpHkaUlQOel6OuoLQ3neq5FWqhnttZPY6Bg6CpNY6DRL1ySCLqKpeHKhCoBQuA8LQYBUHJFBgGSYVAA
       height: 350
   - title: Update Sorting
-    description: 'The data frame sorting can be programmatically updated using the
-      `.update_sort()` method. It takes a list of sorting information or column numbers
-      to apply to the data frame. When using a number, the default sorting direction
-      will be applied. When providing a sorting info object, `col` and `desc` describe
-      the column index and whether or not the sorting direction is descending. To
-      reset the sorting, provide `None` for the sorting information (`.update_sort(None)`).
-
-      '
+    description: |
+      The data frame sorting can be programmatically updated using the `.update_sort()` method. It takes a list of sorting information or column numbers to apply to the data frame. When using a number, the default sorting direction will be applied. When providing a sorting info object, `col` and `desc` describe the column index and whether or not the sorting direction is descending. To reset the sorting, provide `None` for the sorting information (`.update_sort(None)`).
     apps:
     - title: Preview
       file: app-variation-update-sort-core.py
@@ -223,11 +203,8 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZdKAG3gfWoHMBXAJYQAzskEx0pBhWTtSUACYB9HhAHCRAHQiNmyEQAthucZOmyAgpiIM4UYhUEA3OLeqK4DIkJ061GqLIALxyCioBQqIAFACUftCYykIhyEI4ULxwynTsQorROsjFaYJYhgBMhWAAChxcyDV8UdpgsQRFJenC6PwUyg5O5MoARn0U5NX86IpQVMoicOxwjoLkWoTIGwCqM3NwBksrQxAb7Z3F3RC9-YNrEKPjkxt2i-2Ly6vrmxsASnBvQ6fE5nDoQEqlcoAVmqAGF+Aw7JQgcd7igNkQQBtiOwoCJWuiwOgKABaCobAC+53BXTKpD6N2UZE81UimgWRy+pzaYIh6XpFEZswoUByDFgcFZzXZijooJ08VOEE8dEODFcDGiPT6RAFNyIi3x91iiASEIAAkjPAwsMy4BdkCrWNLRBzgfc4qaaRDinYKAjwWzXbLbUt2G7UZNYsAXqQAO6tAC6yAAxMgADzps0lS0eLxYYWixgSh1OoMiZSyz3FNOZh0Qv0B5BW-MAETmUAA4gxBAVywbOSdlDBSJ5grGE2caxms0qLXY7q4sHA6HRjsUHbnF3Bl65KFrrn0sNNhdkPpGILEtt7kHjcBBiI6V8hlNXp3WbxCoHGoIJZOXKzoY89nmYgwwjLloixMAKFwHgNkJJg4wxLYwCQglkGAABGIgKiIAAORMqVTGcHU3BdViXFc10ccj7Eonc4D3CgDxuLBXjgd5B2NB07wfJ9VVfE131nH0Sm-X9-xdCsQxPfYmXA89IOg2D4NoCcUInDDgCIq8RISDB0FSax0GiQzkkEAd1S8RVNhguCEBQGC4AADwoMAKUTIA
       height: 350
   - title: Customize Summary Statement
-    description: 'Set `summary` in `render.DataGrid()` to `False` to remove the statement
-      "Viewing rows 1 through 10 of 20". Set it to a string template containing `{start}`,
-      `{end}`, and `{total}` tokens, to customize the message.
-
-      '
+    description: |
+      Set `summary` in `render.DataGrid()` to `False` to remove the statement "Viewing rows 1 through 10 of 20". Set it to a string template containing `{start}`, `{end}`, and `{total}` tokens, to customize the message.
     apps:
     - title: Preview
       file: app-variation-customize-summary-statement-core.py

--- a/components/outputs/data-table/index.qmd
+++ b/components/outputs/data-table/index.qmd
@@ -30,15 +30,15 @@ listing:
     dir: components/outputs/data-table/
   contents:
   - title: ui.output_data_frame
-    href: https://shiny.posit.co/py/api/ui.output_data_frame.html
+    href: https://shiny.posit.co/py/api/core/ui.output_data_frame.html#shiny.ui.output_data_frame
     signature: ui.output_data_frame(id)
   - title: '@render.data_frame'
-    href: https://shiny.posit.co/py/api/render.data_frame.html
-    signature: render.data_frame(fn=None)
+    href: https://shiny.posit.co/py/api/core/render.data_frame.html#shiny.render.data_frame
+    signature: render.data_frame(fn)
   - title: render.DataTable
-    href: https://shiny.posit.co/py/api/render.DataTable.html
-    signature: render.DataTable(self, data, *, width='fit-content', height='500px',
-      summary=True, filters=False, row_selection_mode='none')
+    href: https://shiny.posit.co/py/api/core/render.DataTable.html#shiny.render.DataTable
+    signature: render.DataTable(data, *, width='fit-content', height='500px', summary=True,
+      filters=False, editable=False, selection_mode='none', styles=None, row_selection_mode='deprecated')
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:
@@ -138,15 +138,9 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZdKAG3gfWoHMBXAJYQAzskEx0pBhWTtSUACYB9HhAHCRAHQiNmyEQAthucZOmyAgpiINqiuAyJCdOtRtHIAvHIUr3QqIAFACUrtCYykLeyEI4ULxwynTsQopBOshZsYJYhgBMGWAAChxcyMV8gdpgIQSZ2XGk-BToLcqKUBRQyQywcEUBmh10WrX1EGEQ4Q50Bo4Abo5Bwm0URM2tLUQicCIiguQhiA1ZAAJ2EA4MWJ3dvf2nyLOsVcOKdKEnENm-yHYUfgMH6Xa5YAAiXSgABUoAAjdgDIaiIgAd0Eigohi8YwAzAAGfHoAAeYyIhjggl4hgoOLA+QArETSbUsgBiZAAHk54R0GHQMWs6CC-Kigh2i0cU0IqAouB4tDAVGJFDAAF8ALpAA
       height: 350
   - title: Styling
-    description: 'Set `styles` in `render.DataGrid()` to a customize the table display.
-      `styles` can take a list of dictionaries where each dictionary represents a
-      style to be applied to the table (and thus should have at least a `style` (or
-      `class`) key to apply CSS styles or classes to the relevant cells). To scope
-      the styling to particular cells, use the `rows` and `cols` keys (with 0-based
-      indexing).
-
-      Note that if both `rows` and `cols` are specified, the style will be applied
-      only to the intersection of the specified rows and columns.'
+    description: |-
+      Set `styles` in `render.DataGrid()` to a customize the table display. `styles` can take a list of dictionaries where each dictionary represents a style to be applied to the table (and thus should have at least a `style` (or `class`) key to apply CSS styles or classes to the relevant cells). To scope the styling to particular cells, use the `rows` and `cols` keys (with 0-based indexing).
+      Note that if both `rows` and `cols` are specified, the style will be applied only to the intersection of the specified rows and columns.
     apps:
     - title: Preview
       file: app-variation-styles-core.py
@@ -160,16 +154,8 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQEsZ1SAnC5dKCAEygGdk+7LgB0IAM2akY7KABt4zdNQDmAVzoR+DJq2SzSULgH0lENRt6iJU5LwAWG3Mm0s2AQUxFm1LnGZF1UVFTc01kAF49A2MQ9U0ACgBKIOhMI3UI5HUcKGU4IzFZdS540WRyrLosOwAmUrAABTkFZAaVOMswRIIyiuzSVQp0QaMeCigC5lg4etiLUbFhLp6IZIgU3zFbPwA3P3iNYYoiAaHBol44Xl46ckTEXvKAAW9uPywxiYlpx+RN9na8y4YiSDwgFQhyG8FFUzHBr18zCwABEoOMACpQABGshmv0hFTmmiwdH0xGAwAADEQAIxEGqU6nIBl05AAZkZRA5NIAukREHz8QTbBRcLjeOFgOUAMTIAA8cqFwoqsoAwtQqMxkBQ7HBtXAAB5sUhbOBQYh2ZDEOCyWTIeKqG5mZAAIVIpAovAoU3QWQopLooqtsj4vESyFlCqVyuQIBl8sV4JjyaWxBD1yWKCWVCNAFprZQ-EsiBGE9HlQBfEuRxPJgmyt2yLja3XIMR0Zheq2kIowcE18vCuOlqNJuvC1M9zooKl8+Oj8fKpZesVwTOxpZicgUXMAdzgdGUdgo66WWJ7IjAVfntcX5WvI9vd9lAAlD3ZZO+2Dq9UTu-pO0fQcCRAYCYyWSRd2nZAqVpOcgLHO8KknWRoNnasy0QpDkGXUVcXXUCwCxc0AGtlEkVRuHzHsWFPMBpTEMQuGIxYrwwhckIfAcsLrYduOwiEINIKD12AGouXg-iBPKFC0MpSTMOkmSwBXfDaEI4jiDIiiqLIAC6OlLEaS4AA2Uyli4xTOPYp9Fz4qzpKEkTaGAAAWIgAFYFI4xywD0uTvNs7DcNXAiz1I8iBl0mjmAM0yoAATjEGoLJssCIUsnyY0C6M1hSDBfUiDx0HiAr0joC5dj8NZCFQUUlFoMAcwoK8eSAA
       height: 350
   - title: Update Filters
-    description: 'The data frame filters can be programmatically updated using the
-      `.update_filter()` method. It takes a list of column filters to apply to the
-      data frame. Each column filter is a dictionary with the following keys: `col`
-      and `value`. The `col` key is the column index to filter on, and the `value`
-      key is the value to filter for. The `value` key can be a single value for string
-      columns or a list of values to filter for numeric columns. Note, to not set
-      a minimum or maximum value for a numeric column, you can provide a `None` value.
-      To reset filters, provide `None` for the filters (`.update_filter(None)`).
-
-      '
+    description: |
+      The data frame filters can be programmatically updated using the `.update_filter()` method. It takes a list of column filters to apply to the data frame. Each column filter is a dictionary with the following keys: `col` and `value`. The `col` key is the column index to filter on, and the `value` key is the value to filter for. The `value` key can be a single value for string columns or a list of values to filter for numeric columns. Note, to not set a minimum or maximum value for a numeric column, you can provide a `None` value. To reset filters, provide `None` for the filters (`.update_filter(None)`).
     apps:
     - title: Preview
       file: app-variation-update-filter-core.py
@@ -183,14 +169,8 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZdKAG3gfWoHMBXAJYQAzskEx0pBhWTtSUACYB9HhAHCRAHQiNmyEQAthucZOmyAgpiIM4UYhUEA3OLeqK4DIkJ061GqLIALxyCioBQqIAFACUftCYykIhyEI4ULxwynTsQorROsjFaYJYhgBMhWAAChxcyDV8UdpgsQRFJenC6PwUyg5O5MoARn0U5NX86IpQVDmC7FQMrURaYACqM3NwyHSLy63tncXdEL39g4LDYxQTENV2InD9+0teq8jrAEpwz7JvQ7rY4QEqlcoAVmqAGF+Aw7JQ9gcPih1kQQOtiOwoCJWqiwOgKABaCrrAC+ILB6VIfQuyjInmqkU0C3eDGBHVBXTKNIodNmFCgOQYsDgTOaLMUdA5OniEASnjoBi8rgY0R6fSIvIuRGeuOuEFiiASYIAAgjPAwsAy4CdkIrWBLRKzlnFjVywcU7BQ4aDmc6pVhAV44sUAMTIAA8kZNJXNHi8WAFQsYortDv9ImUUrddrB3t9yAtiYAInMoAAVKAjdhizNEYMrYIVhj8OCxcNRmPyj3IeNXVxYOB0OhwRx2-uOFxwIeuSjq859LDTAXZRsiOVgnG4CDEe3D5DKXO9rcAdygglkmezdGX23mjeinejec9xWAz+7b+-JQjAGUXlYKAZEEDhkBgOZiEMZAIxfE8fxKDEwDIdh1hQAAGNYwGcDg2zQr4wAAcWockiBgrtXwQ8iANkGBhGQHC8l2WCvyoz0kJQ-CKiwxi8NoaIIUw5AADlyHbMkyJYyiEP-QCIIADwY3DmIo+CqI40hUNoABmHjlPw6JRIgNxkAARgAdliCTP2kn9ZNkEV1BUuC2PYzFNPwgAWPSmIMioKiE-yISsyTVNcgBdUKXO-DtyLgic7AHGdh1Hcde0nJxBzgOcKAXC4sCeF4XQ+TcSm3Xd9yVI8jWkqBz0vR11BaG871XYq1SM9sbJ7HQMHQVJrHQaI+uSQRdRVLw5UIVAKFwHhaDAKh5IoMAyXCoA
       height: 350
   - title: Update Sorting
-    description: 'The data frame sorting can be programmatically updated using the
-      `.update_sort()` method. It takes a list of sorting information or column numbers
-      to apply to the data frame. When using a number, the default sorting direction
-      will be applied. When providing a sorting info object, `col` and `desc` describe
-      the column index and whether or not the sorting direction is descending. To
-      reset the sorting, provide `None` for the sorting information (`.update_sort(None)`).
-
-      '
+    description: |
+      The data frame sorting can be programmatically updated using the `.update_sort()` method. It takes a list of sorting information or column numbers to apply to the data frame. When using a number, the default sorting direction will be applied. When providing a sorting info object, `col` and `desc` describe the column index and whether or not the sorting direction is descending. To reset the sorting, provide `None` for the sorting information (`.update_sort(None)`).
     apps:
     - title: Preview
       file: app-variation-update-sort-core.py
@@ -223,11 +203,8 @@ listing:
       shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZdKAG3gfWoHMBXAJYQAzskEx0pBhWTtSUACYB9HhAHCRAHQiNmyEQAthucZOmyAgpiIM4UYhUEA3OLeqK4DIkJ061GqLIALxyCioBQqIAFACUftCYykIhyEI4ULxwynTsQorROsjFaYJYhgBMhWAAChxcyDV8UdpgsQRFJenC6PwUyg5O5MoARn0U5NX86IpQVMoicOxwjoLkWoTIGwCqM3NwBksrQxAb7Z3F3RC9-YNrEKPjkxt2i-2Ly6vrmxsASnBvQ6fE5nDoQEqlcoAVmqAGF+Aw7JQgcd7igNkQQBtiOwoCJWuiwOgKABaCobAC+53BXTKpD6N2UZE81UimgWRy+pzaYIh6XpFEZswoUByDFgcFZzXZijooJ08VOEE8dEODFcDGiPT6RAFNyIi3x91iiASEIAAkjPAwsMy4BdkCrWNLRBzgfc4qaaRDinYKAjwWzXbLbUt2G7UZNYsAXqQAO6tAC6yAAxMgADzps0lS0eLxYYWixgSh1OoMiZSyz3FNOZh0Qv0B5BW-MAETmUAAKlARstouWDZyTsoYKRPMFYwmzjWM1mlRa7HdXFg4HQ6Mdig7c0u4CvXJQtdc+lhpsLsh9IxBYltvcg8bgIMRHavkMpqzO67eIVA41BBLJy0rOgTz2eZiDDCMuWiLEwAoXAeA2QkmDjDEtjAZCCWQYAAEYiAqIgAA5EypVNZwdLdF1WZdV3XRwKPsKjdzgfcKEPG4sFeOB3iHY0HXvR9n1VN8TQ-OcfRKH8-wAl0KxDU99iZCCLygmC4IQ2hJ1QydMOAYjr1EhIMHQVJrHQaIjOSQRB3VLxFU2WD4IQFBYLgAAPCgwApRMgA
       height: 350
   - title: Customize Summary Statement
-    description: 'Set `summary` in `render.DataGrid()` to `False` to remove the statement
-      "Viewing rows 1 through 10 of 20". Set it to a string template containing `{start}`,
-      `{end}`, and `{total}` tokens, to customize the message.
-
-      '
+    description: |
+      Set `summary` in `render.DataGrid()` to `False` to remove the statement "Viewing rows 1 through 10 of 20". Set it to a string template containing `{start}`, `{end}`, and `{total}` tokens, to customize the message.
     apps:
     - title: Preview
       file: app-variation-customize-summary-statement-core.py

--- a/components/outputs/image/index.qmd
+++ b/components/outputs/image/index.qmd
@@ -28,11 +28,11 @@ listing:
     dir: components/outputs/image/
   contents:
   - title: ui.output_image
-    href: https://shiny.posit.co/py/api/ui.output_image.html
+    href: https://shiny.posit.co/py/api/core/ui.output_image.html#shiny.ui.output_image
     signature: ui.output_image(id, width='100%', height='400px', *, inline=False,
       click=False, dblclick=False, hover=False, brush=False, fill=False)
   - title: '@render.image'
-    href: https://shiny.posit.co/py/api/render.image.html
+    href: https://shiny.posit.co/py/api/core/render.image.html#shiny.render.image
     signature: render.image(_fn=None, *, delete_file=False)
 ---
 

--- a/components/outputs/plot-matplotlib/index.qmd
+++ b/components/outputs/plot-matplotlib/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/outputs/plot-matplotlib/
   contents:
   - title: ui.output_plot
-    href: https://shiny.posit.co/py/api/ui.output_plot.html
+    href: https://shiny.posit.co/py/api/core/ui.output_plot.html#shiny.ui.output_plot
     signature: ui.output_plot(id, width='100%', height='400px', *, inline=False, click=False,
       dblclick=False, hover=False, brush=False, fill=MISSING)
   - title: '@render.plot'
-    href: https://shiny.posit.co/py/api/render.plot.html
+    href: https://shiny.posit.co/py/api/core/render.plot.html#shiny.render.plot
     signature: render.plot(_fn=None, *, alt=None, width=MISSING, height=MISSING, **kwargs)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/outputs/plot-seaborn/index.qmd
+++ b/components/outputs/plot-seaborn/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/outputs/plot-seaborn/
   contents:
   - title: ui.output_plot
-    href: https://shiny.posit.co/py/api/ui.output_plot.html
+    href: https://shiny.posit.co/py/api/core/ui.output_plot.html#shiny.ui.output_plot
     signature: ui.output_plot(id, width='100%', height='400px', *, inline=False, click=False,
       dblclick=False, hover=False, brush=False, fill=MISSING)
   - title: '@render.plot'
-    href: https://shiny.posit.co/py/api/render.plot.html
+    href: https://shiny.posit.co/py/api/core/render.plot.html#shiny.render.plot
     signature: render.plot(_fn=None, *, alt=None, width=MISSING, height=MISSING, **kwargs)
 ---
 

--- a/components/outputs/text/index.qmd
+++ b/components/outputs/text/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/outputs/text/
   contents:
   - title: ui.output_text
-    href: https://shiny.posit.co/py/api/ui.output_text.html
+    href: https://shiny.posit.co/py/api/core/ui.output_text.html#shiny.ui.output_text
     signature: ui.output_text(id, inline=False, container=None)
   - title: '@render.text'
-    href: https://shiny.posit.co/py/api/render.text.html
-    signature: render.text(fn=None)
+    href: https://shiny.posit.co/py/api/core/render.text.html#shiny.render.text
+    signature: render.text(_fn=None, *, inline=False)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/outputs/ui/index.qmd
+++ b/components/outputs/ui/index.qmd
@@ -23,22 +23,22 @@ listing:
     dir: components/outputs/ui/
   contents:
   - title: ui.output_ui
-    href: https://shiny.posit.co/py/api/ui.output_ui.html
+    href: https://shiny.posit.co/py/api/core/ui.output_ui.html#shiny.ui.output_ui
     signature: ui.output_ui(id, inline=False, container=None, fill=False, fillable=False,
       **kwargs)
   - title: '@render.ui'
-    href: https://shiny.posit.co/py/api/render.ui.html
+    href: https://shiny.posit.co/py/api/core/render.ui.html#shiny.render.ui
     signature: render.ui(_fn=None)
   - title: '@render.express'
-    href: https://shiny.posit.co/py/api/express/express.render.express.html
-    signature: express.render.express(self, _fn=None, *, inline=False, container=None,
-      fill=False, fillable=False, **kwargs)
+    href: https://shiny.posit.co/py/api/core/render.express.html#shiny.render.express
+    signature: render.express(_fn=None, *, inline=False, container=None, fill=False,
+      fillable=False, **kwargs)
   - title: ui.insert_ui
-    href: https://shiny.posit.co/py/api/ui.insert_ui.html
+    href: https://shiny.posit.co/py/api/core/ui.insert_ui.html#shiny.ui.insert_ui
     signature: ui.insert_ui(ui, selector, where='beforeEnd', multiple=False, immediate=False,
       session=None)
   - title: ui.remove_ui
-    href: https://shiny.posit.co/py/api/ui.remove_ui.html
+    href: https://shiny.posit.co/py/api/core/ui.remove_ui.html#shiny.ui.remove_ui
     signature: ui.remove_ui(selector, multiple=False, immediate=False, session=None)
 - id: variations
   template: ../../_partials/components-variations.ejs
@@ -46,14 +46,9 @@ listing:
     dir: components/outputs/ui/
   contents:
   - title: Create dependent controls
-    description: 'You can use `@render.ui` or `@render.express` and `ui.output_ui()`
-      to create a set of controls that are dependent on a setting in your app. In
-      this example, we show a different set of options when the app is in "plot" or
-      "table" mode.
-
-      Note that we use the current input values or a default value when creating the
-      dependent controls. Without this, the values are re-initialized every time and
-      forget previous user input.'
+    description: |-
+      You can use `@render.ui` or `@render.express` and `ui.output_ui()` to create a set of controls that are dependent on a setting in your app. In this example, we show a different set of options when the app is in "plot" or "table" mode.
+      Note that we use the current input values or a default value when creating the dependent controls. Without this, the values are re-initialized every time and forget previous user input.
     apps:
     - title: Preview
       file: app-variation-update-an-input-core.py

--- a/components/outputs/value-box/index.qmd
+++ b/components/outputs/value-box/index.qmd
@@ -24,28 +24,28 @@ listing:
     dir: components/outputs/value-box/
   contents:
   - title: ui.value_box
-    href: https://shiny.posit.co/py/api/ui.value_box.html
+    href: https://shiny.posit.co/py/api/core/ui.value_box.html#shiny.ui.value_box
     signature: ui.value_box(title, value, *args, showcase=None, showcase_layout='left
-      center', full_screen=False, theme=None, height=None, max_height=None, fill=True,
-      class_=None, **kwargs)
+      center', full_screen=False, theme=None, height=None, max_height=None, min_height=None,
+      fill=True, class_=None, id=None, **kwargs)
   - title: ui.card
-    href: https://shiny.posit.co/py/api/ui.card.html#shiny.ui.card
+    href: https://shiny.posit.co/py/api/core/ui.card.html#shiny.ui.card
     signature: ui.card(*args, full_screen=False, height=None, max_height=None, min_height=None,
-      fill=True, class_=None, **kwargs)
+      fill=True, class_=None, id=None, **kwargs)
   - title: ui.showcase_left_center
-    href: https://shiny.posit.co/py/api/ui.showcase_left_center.html
-    signature: ui.showcase_left_center(*, width='30%', width_full_screen='1fr', max_height='100px',
+    href: https://shiny.posit.co/py/api/core/ui.showcase_left_center.html#shiny.ui.showcase_left_center
+    signature: ui.showcase_left_center(width='30%', width_full_screen='1fr', max_height='100px',
       max_height_full_screen='67%')
   - title: ui.showcase_top_right
-    href: https://shiny.posit.co/py/api/ui.showcase_top_right.html
-    signature: ui.showcase_top_right(*, width='40%', width_full_screen='1fr', max_height='75px',
+    href: https://shiny.posit.co/py/api/core/ui.showcase_top_right.html#shiny.ui.showcase_top_right
+    signature: ui.showcase_top_right(width='40%', width_full_screen='1fr', max_height='75px',
       max_height_full_screen='67%')
   - title: ui.showcase_bottom
-    href: https://shiny.posit.co/py/api/ui.showcase_bottom.html
-    signature: ui.showcase_bottom(*, width='100%', width_full_screen=None, height='auto',
+    href: https://shiny.posit.co/py/api/core/ui.showcase_bottom.html#shiny.ui.showcase_bottom
+    signature: ui.showcase_bottom(width='100%', width_full_screen=None, height='auto',
       height_full_screen='2fr', max_height='100px', max_height_full_screen=None)
   - title: ui.value_box_theme
-    href: https://shiny.posit.co/py/api/ui.value_box_theme.html
+    href: https://shiny.posit.co/py/api/core/ui.value_box_theme.html#shiny.ui.value_box_theme
     signature: ui.value_box_theme(name=None, *, fg=None, bg=None)
 - id: variations
   template: ../../_partials/components-variations.ejs

--- a/components/outputs/verbatim-text/index.qmd
+++ b/components/outputs/verbatim-text/index.qmd
@@ -24,11 +24,11 @@ listing:
     dir: components/outputs/verbatim-text/
   contents:
   - title: ui.output_text_verbatim
-    href: https://shiny.posit.co/py/api/ui.output_text_verbatim.html
+    href: https://shiny.posit.co/py/api/core/ui.output_text_verbatim.html#shiny.ui.output_text_verbatim
     signature: ui.output_text_verbatim(id, placeholder=False)
   - title: '@render.text'
-    href: https://shiny.posit.co/py/api/render.text.html
-    signature: render.text(fn=None)
+    href: https://shiny.posit.co/py/api/core/render.text.html#shiny.render.text
+    signature: render.text(_fn=None, *, inline=False)
 - id: variations
   template: ../../_partials/components-variations.ejs
   template-params:

--- a/components/test_relevant_functions.py
+++ b/components/test_relevant_functions.py
@@ -205,3 +205,13 @@ def test_flatten_preserves_single_element_tuple_default():
 def test_flatten_single_element_tuple_default_last_arg():
     block = "ui.foo(\n    y=2,\n    x=(1,),\n)"
     assert flatten_python_block(block) == "ui.foo(y=2, x=(1,))"
+
+
+def test_find_index_qmds_is_cwd_independent(monkeypatch, tmp_path):
+    """Discovery is anchored to the repo root, not the CWD (regression)."""
+    from _relevant_functions import find_index_qmds
+
+    monkeypatch.chdir(tmp_path)  # anywhere other than the repo root
+    qmds = find_index_qmds()
+    assert len(qmds) > 40, f"expected >40 index.qmd files, found {len(qmds)}"
+    assert all(q.endswith("index.qmd") for q in qmds)

--- a/components/test_relevant_functions.py
+++ b/components/test_relevant_functions.py
@@ -116,3 +116,42 @@ def test_extract_signature_block_missing_anchor_raises(tmp_path):
 def test_skip_titles_contains_external_and_instance_forms():
     assert "shinywidgets.output_widget" in SKIP_TITLES
     assert "chat.append_message()" in SKIP_TITLES
+
+
+def test_find_index_qmds_discovers_many():
+    from _relevant_functions import find_index_qmds
+
+    qmds = find_index_qmds()
+    assert len(qmds) > 40, f"expected >40 index.qmd files, found {len(qmds)}"
+    assert all(q.endswith("index.qmd") for q in qmds)
+
+
+def test_rewrite_is_idempotent(tmp_path, monkeypatch):
+    """Rewriting an already-fresh page produces no further change."""
+    from _relevant_functions import rewrite_relevant_functions
+
+    api = _write_api(tmp_path)
+    page = tmp_path / "comp" / "index.qmd"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\n"
+        "title: X\n"
+        "listing:\n"
+        "- id: relevant-functions\n"
+        "  template: t.ejs\n"
+        "  template-params:\n"
+        "    dir: comp/\n"
+        "  contents:\n"
+        "  - title: ui.value_box\n"
+        "    href: stale\n"
+        "    signature: stale\n"
+        "---\n\n"
+        "body\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert rewrite_relevant_functions("comp/index.qmd", api_dir=api) is True
+    first = page.read_text()
+    assert "core/ui.value_box.html#shiny.ui.value_box" in first
+    assert "stale" not in first
+    rewrite_relevant_functions("comp/index.qmd", api_dir=api)
+    assert page.read_text() == first  # idempotent

--- a/components/test_relevant_functions.py
+++ b/components/test_relevant_functions.py
@@ -195,3 +195,13 @@ def test_rewrite_emits_literal_block_for_multiline_description(tmp_path, monkeyp
         "as a folded block scalar.\n"
     ) in result
     assert "core/ui.value_box.html#shiny.ui.value_box" in result
+
+
+def test_flatten_preserves_single_element_tuple_default():
+    block = "ui.foo(\n    x=(1,),\n    y=2,\n)"
+    assert flatten_python_block(block) == "ui.foo(x=(1,), y=2)"
+
+
+def test_flatten_single_element_tuple_default_last_arg():
+    block = "ui.foo(\n    y=2,\n    x=(1,),\n)"
+    assert flatten_python_block(block) == "ui.foo(y=2, x=(1,))"

--- a/components/test_relevant_functions.py
+++ b/components/test_relevant_functions.py
@@ -197,6 +197,56 @@ def test_rewrite_emits_literal_block_for_multiline_description(tmp_path, monkeyp
     assert "core/ui.value_box.html#shiny.ui.value_box" in result
 
 
+def _write_page_with_unresolvable_title(tmp_path: Path) -> Path:
+    page = tmp_path / "comp" / "index.qmd"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\n"
+        "title: X\n"
+        "listing:\n"
+        "- id: relevant-functions\n"
+        "  template: t.ejs\n"
+        "  template-params:\n"
+        "    dir: comp/\n"
+        "  contents:\n"
+        "  - title: ui.value_box\n"
+        "    href: stale\n"
+        "    signature: stale\n"
+        "  - title: ui.does_not_exist\n"
+        "    href: keep-me\n"
+        "    signature: keep-me\n"
+        "---\n\n"
+        "body\n"
+    )
+    return page
+
+
+def test_rewrite_strict_raises_on_unresolvable_title(tmp_path, monkeypatch):
+    from _relevant_functions import rewrite_relevant_functions
+
+    api = _write_api(tmp_path)
+    page = _write_page_with_unresolvable_title(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(TitleResolutionError):
+        rewrite_relevant_functions("comp/index.qmd", api_dir=api, strict=True)
+
+
+def test_rewrite_non_strict_falls_forward(tmp_path, monkeypatch):
+    """Non-strict leaves the unresolvable entry as-authored but still rewrites
+    the resolvable ones -- a single rotted title never aborts the run."""
+    from _relevant_functions import rewrite_relevant_functions
+
+    api = _write_api(tmp_path)
+    page = _write_page_with_unresolvable_title(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    assert rewrite_relevant_functions("comp/index.qmd", api_dir=api, strict=False) is True
+    result = page.read_text()
+    # Resolvable entry was regenerated ...
+    assert "core/ui.value_box.html#shiny.ui.value_box" in result
+    # ... while the unresolvable one kept its hand-authored fields.
+    assert "keep-me" in result
+
+
 def test_flatten_preserves_single_element_tuple_default():
     block = "ui.foo(\n    x=(1,),\n    y=2,\n)"
     assert flatten_python_block(block) == "ui.foo(x=(1,), y=2)"

--- a/components/test_relevant_functions.py
+++ b/components/test_relevant_functions.py
@@ -155,3 +155,43 @@ def test_rewrite_is_idempotent(tmp_path, monkeypatch):
     assert "stale" not in first
     rewrite_relevant_functions("comp/index.qmd", api_dir=api)
     assert page.read_text() == first  # idempotent
+
+
+def test_rewrite_emits_literal_block_for_multiline_description(tmp_path, monkeypatch):
+    """Multi-line front-matter strings (e.g. a folded `>` description) should be
+    re-serialized as clean YAML literal blocks (`|`), not single-quoted scalars."""
+    from _relevant_functions import rewrite_relevant_functions
+
+    api = _write_api(tmp_path)
+    page = tmp_path / "comp" / "index.qmd"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\n"
+        "title: X\n"
+        "description: >\n"
+        "  This is a longer description that spans\n"
+        "  multiple lines when authored as a folded\n"
+        "  block scalar.\n"
+        "listing:\n"
+        "- id: relevant-functions\n"
+        "  template: t.ejs\n"
+        "  template-params:\n"
+        "    dir: comp/\n"
+        "  contents:\n"
+        "  - title: ui.value_box\n"
+        "    href: stale\n"
+        "    signature: stale\n"
+        "---\n\n"
+        "body\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert rewrite_relevant_functions("comp/index.qmd", api_dir=api) is True
+    result = page.read_text()
+
+    assert "description: |" in result
+    assert "description: '" not in result
+    assert (
+        "This is a longer description that spans multiple lines when authored "
+        "as a folded block scalar.\n"
+    ) in result
+    assert "core/ui.value_box.html#shiny.ui.value_box" in result

--- a/components/test_relevant_functions.py
+++ b/components/test_relevant_functions.py
@@ -1,0 +1,118 @@
+# components/test_relevant_functions.py
+from pathlib import Path
+
+import pytest
+
+from _relevant_functions import (
+    SKIP_TITLES,
+    TitleResolutionError,
+    extract_signature_block,
+    flatten_python_block,
+    normalize_title,
+    resolve_title,
+)
+
+VALUE_BOX_QMD = """# ui.value_box { #shiny.ui.value_box }
+
+```python
+ui.value_box(
+    title,
+    value,
+    *args,
+    showcase=None,
+    showcase_layout='left center',
+    full_screen=False,
+    theme=None,
+    height=None,
+    max_height=None,
+    min_height=None,
+    fill=True,
+    class_=None,
+    id=None,
+    **kwargs,
+)
+```
+
+Value box
+"""
+
+PROGRESS_QMD = """# ui.Progress { #shiny.ui.Progress }
+
+```python
+ui.Progress(min=0, max=1, session=None)
+```
+
+## Methods
+
+### close { #shiny.ui.Progress.close }
+
+```python
+ui.Progress.close()
+```
+
+Close the progress bar.
+"""
+
+
+def _write_api(tmp_path: Path) -> Path:
+    api = tmp_path / "core"
+    api.mkdir()
+    (api / "ui.value_box.qmd").write_text(VALUE_BOX_QMD)
+    (api / "ui.Progress.qmd").write_text(PROGRESS_QMD)
+    return api
+
+
+def test_flatten_python_block_multiline():
+    block = "ui.value_box(\n    title,\n    value,\n    **kwargs,\n)"
+    assert flatten_python_block(block) == "ui.value_box(title, value, **kwargs)"
+
+
+def test_flatten_python_block_no_args():
+    assert flatten_python_block("ui.Progress.close()") == "ui.Progress.close()"
+
+
+def test_normalize_title_strips_decorator_call_and_express():
+    assert normalize_title("@render.plot") == "render.plot"
+    assert normalize_title("ui.input_file()") == "ui.input_file"
+    assert normalize_title("express.ui.input_file") == "ui.input_file"
+
+
+def test_resolve_title_top_level_function(tmp_path):
+    api = _write_api(tmp_path)
+    href, sig = resolve_title("ui.value_box", api_dir=api)
+    assert href == (
+        "https://shiny.posit.co/py/api/core/ui.value_box.html#shiny.ui.value_box"
+    )
+    assert sig == (
+        "ui.value_box(title, value, *args, showcase=None, "
+        "showcase_layout='left center', full_screen=False, theme=None, "
+        "height=None, max_height=None, min_height=None, fill=True, "
+        "class_=None, id=None, **kwargs)"
+    )
+
+
+def test_resolve_title_method_uses_class_file_and_anchor(tmp_path):
+    api = _write_api(tmp_path)
+    href, sig = resolve_title("ui.Progress.close", api_dir=api)
+    assert href == (
+        "https://shiny.posit.co/py/api/core/ui.Progress.html"
+        "#shiny.ui.Progress.close"
+    )
+    assert sig == "ui.Progress.close()"
+
+
+def test_resolve_title_unresolvable_raises(tmp_path):
+    api = _write_api(tmp_path)
+    with pytest.raises(TitleResolutionError) as exc:
+        resolve_title("ui.does_not_exist", api_dir=api)
+    assert "ui.does_not_exist" in str(exc.value)
+
+
+def test_extract_signature_block_missing_anchor_raises(tmp_path):
+    with pytest.raises(TitleResolutionError):
+        extract_signature_block(VALUE_BOX_QMD, "shiny.ui.nope")
+
+
+def test_skip_titles_contains_external_and_instance_forms():
+    assert "shinywidgets.output_widget" in SKIP_TITLES
+    assert "chat.append_message()" in SKIP_TITLES

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -81,7 +81,10 @@ _MUTATORS = {
 }
 
 # Deprecated / superseded functions that intentionally have no doc page.
-_DEPRECATED = {"column", "row"}  # superseded by layout_columns / layout_column_wrap
+_DEPRECATED = {
+    "column", "row",  # superseded by layout_columns / layout_column_wrap
+    "update_navs",  # superseded by update_navset
+}
 
 # TODO: layout / navigation / page / panel functions not yet documented in a
 # ``layouts/`` page. The ``layouts/`` files' ``relevant-functions`` blocks are

--- a/components/update-relevant-functions.py
+++ b/components/update-relevant-functions.py
@@ -1,0 +1,38 @@
+"""Regenerate relevant-functions title/href/signature from the API pages.
+
+With no args, rewrites every component + layout page. Given path args (dirs,
+index.qmd files, or any file inside a component dir), rewrites only those pages.
+Run AFTER ``make quartodoc`` (the generated api/core pages are the input).
+"""
+
+import logging
+import sys
+
+from _relevant_functions import (
+    find_index_qmds,
+    resolve_index_qmds,
+    rewrite_relevant_functions,
+)
+
+lg = logging.getLogger("relevant-functions")
+if not lg.handlers:
+    h = logging.StreamHandler()
+    h.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    lg.addHandler(h)
+    lg.setLevel(logging.INFO)
+
+
+def main(argv: list[str]) -> None:
+    qmds = resolve_index_qmds(argv) if argv else find_index_qmds()
+    if not argv:
+        # Guard: a broken glob that silently finds nothing must not pass.
+        assert len(qmds) > 40, (
+            f"Expected >40 index.qmd files, found {len(qmds)}. Discovery broken?"
+        )
+    for qmd in qmds:
+        if rewrite_relevant_functions(qmd):
+            lg.info(f"updated {qmd}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/components/update-relevant-functions.py
+++ b/components/update-relevant-functions.py
@@ -1,10 +1,20 @@
 """Regenerate relevant-functions title/href/signature from the API pages.
 
-With no args, rewrites every component + layout page. Given path args (dirs,
-index.qmd files, or any file inside a component dir), rewrites only those pages.
-Run AFTER ``make quartodoc`` (the generated api/core pages are the input).
+With no path args, rewrites every component + layout page. Given path args
+(dirs, index.qmd files, or any file inside a component dir), rewrites only
+those pages. Run AFTER ``make quartodoc`` (the generated api/core pages are
+the input).
+
+Strictness (an unresolvable title = rotted/renamed export):
+
+* ``--strict`` (default): raise, so the run fails. Used by CI, where the
+  correct fields are required before merge.
+* ``--no-strict``: log the unresolvable title and leave it as-authored, so a
+  single rotted entry never aborts the run. Used by the build/setup chain,
+  which "falls forward".
 """
 
+import argparse
 import logging
 import sys
 
@@ -23,14 +33,32 @@ if not lg.handlers:
 
 
 def main(argv: list[str]) -> None:
-    qmds = resolve_index_qmds(argv) if argv else find_index_qmds()
-    if not argv:
+    parser = argparse.ArgumentParser(description=__doc__)
+    strict = parser.add_mutually_exclusive_group()
+    strict.add_argument(
+        "--strict",
+        dest="strict",
+        action="store_true",
+        help="raise on an unresolvable title (default; used by CI)",
+    )
+    strict.add_argument(
+        "--no-strict",
+        dest="strict",
+        action="store_false",
+        help="warn and leave an unresolvable title as-authored (fall forward)",
+    )
+    parser.set_defaults(strict=True)
+    parser.add_argument("paths", nargs="*", help="dirs/files to limit the rewrite to")
+    ns = parser.parse_args(argv)
+
+    qmds = resolve_index_qmds(ns.paths) if ns.paths else find_index_qmds()
+    if not ns.paths:
         # Guard: a broken glob that silently finds nothing must not pass.
         assert len(qmds) > 40, (
             f"Expected >40 index.qmd files, found {len(qmds)}. Discovery broken?"
         )
     for qmd in qmds:
-        if rewrite_relevant_functions(qmd):
+        if rewrite_relevant_functions(qmd, strict=ns.strict):
             lg.info(f"updated {qmd}")
 
 

--- a/layouts/arrange/index.qmd
+++ b/layouts/arrange/index.qmd
@@ -1,27 +1,30 @@
 ---
-title: "Arrange Elements"
-description: >
-  Layout elements into rows and columns that responsively adapt to a wide range of
-  screen sizes.
-
+title: Arrange Elements
+description: |
+  Layout elements into rows and columns that responsively adapt to a wide range of screen sizes.
 listing:
 - id: relevant-functions
   template: ../../components/_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.layout_columns
-    href: https://shiny.posit.co/py/api/ui.layout_columns.html
-    signature: ui.layout_columns(*args, col_widths=None, row_heights=None, fill=True, fillable=True, gap=None, class_=None, height=None, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.layout_columns.html#shiny.ui.layout_columns
+    signature: ui.layout_columns(*args, col_widths=None, row_heights=None, fill=True,
+      fillable=True, gap=None, class_=None, height=None, min_height=None, max_height=None,
+      **kwargs)
   - title: ui.layout_column_wrap
-    href: https://shiny.posit.co/py/api/ui.layout_column_wrap.html
-    signature: ui.layout_columns(*args, col_widths=None, row_heights=None, fill=True, fillable=True, gap=None, class_=None, height=None, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.layout_column_wrap.html#shiny.ui.layout_column_wrap
+    signature: ui.layout_column_wrap(*args, width=MISSING, fixed_width=False, heights_equal='all',
+      fill=True, fillable=True, height=None, min_height=None, max_height=None, height_mobile=None,
+      gap=None, class_=None, **kwargs)
   - title: ui.page_fixed
-    href: https://shiny.posit.co/py/api/ui.page_fixed.html
-    signature: ui.page_fixed(*args, title=None, lang=None, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.page_fixed.html#shiny.ui.page_fixed
+    signature: ui.page_fixed(*args, title=None, lang=None, theme=None, **kwargs)
   - title: ui.page_fillable
-    href: https://shiny.posit.co/py/api/ui.page_fillable.html
-    signature: ui.page_fillable(*args, padding=None, gap=None, fillable_mobile=False, title=None, lang=None, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.page_fillable.html#shiny.ui.page_fillable
+    signature: ui.page_fillable(*args, padding=None, gap=None, fillable_mobile=False,
+      title=None, lang=None, theme=None, **kwargs)
   - title: ui.page_fluid
-    href: https://shiny.posit.co/py/api/ui.page_fluid.html
+    href: https://shiny.posit.co/py/api/core/ui.page_fluid.html#shiny.ui.page_fluid
     signature: ui.page_fluid(*args, title=None, lang=None, theme=None, **kwargs)
 ---
 

--- a/layouts/navbars/index.qmd
+++ b/layouts/navbars/index.qmd
@@ -1,27 +1,30 @@
 ---
-title: "Navbars"
-description: >
-  A navbar adds a navigation bar, allowing users to easily navigate your
-  Shiny app.
-
+title: Navbars
+description: |
+  A navbar adds a navigation bar, allowing users to easily navigate your Shiny app.
 listing:
 - id: relevant-functions
   template: ../../components/_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.page_navbar
-    href: https://shiny.posit.co/py/api/core/ui.page_navbar.html
-    signature: ui.page_navbar(*args, title=None, id=None, selected=None, sidebar=None, fillable=True, fillable_mobile=False, gap=None, padding=None, position='static-top', header=None, footer=None, bg=None, inverse=False, underline=True, collapsible=True, fluid=True, window_title=MISSING, lang=None)
+    href: https://shiny.posit.co/py/api/core/ui.page_navbar.html#shiny.ui.page_navbar
+    signature: ui.page_navbar(*args, title=None, id=None, selected=None, sidebar=None,
+      fillable=False, fillable_mobile=False, gap=None, padding=None, header=None,
+      footer=None, navbar_options=None, fluid=True, window_title=MISSING, lang=None,
+      theme=None, position=DEPRECATED, bg=DEPRECATED, inverse=DEPRECATED, underline=DEPRECATED,
+      collapsible=DEPRECATED)
   - title: ui.nav_panel
-    href: https://shiny.posit.co/py/api/core/ui.nav_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.nav_panel.html#shiny.ui.nav_panel
     signature: ui.nav_panel(title, *args, value=None, icon=None)
   - title: ui.update_nav_panel
-    href: https://shiny.posit.co/py/api/core/ui.update_nav_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.update_nav_panel.html#shiny.ui.update_nav_panel
     signature: ui.update_nav_panel(id, target, method, session=None)
   - title: ui.insert_nav_panel
-    href: https://shiny.posit.co/py/api/core/ui.insert_nav_panel.html
-    signature: ui.insert_nav_panel(id, nav_panel, target=None, position='after', select=False, session=None)
+    href: https://shiny.posit.co/py/api/core/ui.insert_nav_panel.html#shiny.ui.insert_nav_panel
+    signature: ui.insert_nav_panel(id, nav_panel, target=None, position='after', select=False,
+      session=None)
   - title: ui.remove_nav_panel
-    href: https://shiny.posit.co/py/api/core/ui.remove_nav_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.remove_nav_panel.html#shiny.ui.remove_nav_panel
     signature: ui.remove_nav_panel(id, target, session=None)
 ---
 

--- a/layouts/panels-cards/index.qmd
+++ b/layouts/panels-cards/index.qmd
@@ -1,19 +1,17 @@
 ---
 title: Cards and panels
-description: 'Use cards and panels to define areas of related content in your Shiny
-  app.
-
-  '
+description: |
+  Use cards and panels to define areas of related content in your Shiny app.
 listing:
 - id: relevant-functions
   template: ../../components/_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.card
-    href: https://shiny.posit.co/py/api/ui.card.html
+    href: https://shiny.posit.co/py/api/core/ui.card.html#shiny.ui.card
     signature: ui.card(*args, full_screen=False, height=None, max_height=None, min_height=None,
-      fill=True, class_=None, **kwargs)
+      fill=True, class_=None, id=None, **kwargs)
   - title: ui.card_header
-    href: https://shiny.posit.co/py/api/ui.card_header.html
+    href: https://shiny.posit.co/py/api/core/ui.card_header.html#shiny.ui.card_header
     signature: ui.card_header(*args, container=tags.div, **kwargs)
   - title: ui.card_body
     href: https://shiny.posit.co/py/api/ui.card_body.html
@@ -21,21 +19,22 @@ listing:
       max_height_full_screen=None, height=None, padding=None, gap=None, fill=True,
       class_=None, **kwargs)
   - title: ui.card_footer
-    href: https://shiny.posit.co/py/api/ui.card_footer.html
+    href: https://shiny.posit.co/py/api/core/ui.card_footer.html#shiny.ui.card_footer
     signature: ui.card_footer(*args, **kwargs)
   - title: ui.panel_absolute
-    href: https://shiny.posit.co/py/api/ui.panel_absolute.html
+    href: https://shiny.posit.co/py/api/core/ui.panel_absolute.html#shiny.ui.panel_absolute
     signature: ui.panel_absolute(*args, top=None, left=None, right=None, bottom=None,
       width=None, height=None, draggable=False, fixed=False, cursor='auto', **kwargs)
   - title: ui.panel_fixed
-    href: https://shiny.posit.co/py/api/ui.panel_fixed.html
-    signature: ui.panel_fixed(*args, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.panel_fixed.html#shiny.ui.panel_fixed
+    signature: ui.panel_fixed(*args, top=None, left=None, right=None, bottom=None,
+      width=None, height=None, draggable=False, cursor='auto', **kwargs)
   - title: ui.panel_well
     href: https://shiny.posit.co/py/api/ui.panel_well.html
     signature: ui.panel_well(*args, **kwargs)
   - title: ui.panel_title
-    href: https://shiny.posit.co/py/api/ui.panel_title.html
-    signature: ui.panel_title(title, window_title=<shiny.types.MISSING_TYPE object at 0x10529a720>)
+    href: https://shiny.posit.co/py/api/core/ui.panel_title.html#shiny.ui.panel_title
+    signature: ui.panel_title(title, window_title=MISSING)
 - id: variation-hello-card
   template: ../../components/_partials/components-detail-example.ejs
   template-params:

--- a/layouts/sidebars/index.qmd
+++ b/layouts/sidebars/index.qmd
@@ -1,27 +1,28 @@
 ---
-title: "Sidebars"
-description: >
-  A sidebar layout creates a sidebar in your Shiny app, typically used for inputs, and a
-  large main area, typically used for outputs.
-
-
+title: Sidebars
+description: |
+  A sidebar layout creates a sidebar in your Shiny app, typically used for inputs, and a large main area, typically used for outputs.
 listing:
 - id: relevant-functions
   template: ../../components/_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.layout_sidebar
-    href: https://shiny.posit.co/py/api/ui.layout_sidebar.html
-    signature: ui.layout_sidebar(sidebar, *args, fillable=True, fill=True, bg=None, fg=None, border=None, border_radius=None, border_color=None, gap=None, padding=None, height=None, **kwargs)
-
+    href: https://shiny.posit.co/py/api/core/ui.layout_sidebar.html#shiny.ui.layout_sidebar
+    signature: ui.layout_sidebar(sidebar, *args, fillable=True, fill=True, bg=None,
+      fg=None, border=None, border_radius=None, border_color=None, gap=None, padding=None,
+      height=None, **kwargs)
   - title: ui.sidebar
-    href: https://shiny.posit.co/py/api/ui.sidebar.html#shiny.ui.sidebar
-    signature: ui.sidebar(*args, width=250, position='left', open='desktop', id=None, title=None, bg=None, fg=None, class_=None, max_height_mobile=None, gap=None, padding=None)
+    href: https://shiny.posit.co/py/api/core/ui.sidebar.html#shiny.ui.sidebar
+    signature: ui.sidebar(*args, position='left', open=None, width=250, id=None, title=None,
+      bg=None, fg=None, class_=None, max_height_mobile=None, gap=None, padding=None,
+      fillable=False, resizable=True, **kwargs)
   - title: ui.update_sidebar
-    href: https://shiny.posit.co/py/api/ui.update_sidebar.html
+    href: https://shiny.posit.co/py/api/core/ui.update_sidebar.html#shiny.ui.update_sidebar
     signature: ui.update_sidebar(id, *, show=None, session=None)
   - title: ui.page_sidebar
-    href: https://shiny.posit.co/py/api/ui.page_sidebar.html
-    signature: ui.page_sidebar(sidebar, *args, title=None, fillable=False, fillable_mobile=False, window_title=<shiny.types.MISSING_TYPE object at 0x10529a720>, lang=None, theme=None, **kwargs)
+    href: https://shiny.posit.co/py/api/core/ui.page_sidebar.html#shiny.ui.page_sidebar
+    signature: ui.page_sidebar(sidebar, *args, title=None, fillable=False, fillable_mobile=False,
+      window_title=MISSING, lang=None, theme=None, **kwargs)
 ---
 
 ```{python}

--- a/layouts/tabs/index.qmd
+++ b/layouts/tabs/index.qmd
@@ -1,53 +1,47 @@
 ---
-title: "Tabs"
-description: >
+title: Tabs
+description: |
   Tabs and navigation allow you to create Shiny apps with multiple pages.
-
 listing:
 - id: relevant-functions
   template: ../../components/_partials/components-detail-relevant-functions.ejs
   contents:
   - title: ui.accordion
-    href: https://shiny.posit.co/py/api/ui.accordion.html#shiny.ui.accordion
-    signature: ui.accordion(*args, id=None, open=None, multiple=True, class_=None, width=None, height=None, **kwargs)
-
+    href: https://shiny.posit.co/py/api/core/ui.accordion.html#shiny.ui.accordion
+    signature: ui.accordion(*args, id=None, open=None, multiple=True, class_=None,
+      width=None, height=None, **kwargs)
   - title: ui.accordion_panel
-    href: https://shiny.posit.co/py/api/ui.accordion_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.accordion_panel.html#shiny.ui.accordion_panel
     signature: ui.accordion_panel(title, *args, value=MISSING, icon=None, **kwargs)
-
   - title: ui.navset_card_tab
-    href: https://shiny.posit.co/py/api/ui.navset_card_tab.html
-    signature: ui.navset_card_tab(*args, id=None, selected=None, title=None, sidebar=None, header=None, footer=None)
-
+    href: https://shiny.posit.co/py/api/core/ui.navset_card_tab.html#shiny.ui.navset_card_tab
+    signature: ui.navset_card_tab(*args, id=None, selected=None, title=None, sidebar=None,
+      full_screen=False, header=None, footer=None)
   - title: ui.navset_card_pill
-    href: https://shiny.posit.co/py/api/ui.navset_card_pill.html
-    signature: ui.navset_card_pill(*args, id=None, selected=None, title=None, sidebar=None, header=None, footer=None, placement='above')
-
+    href: https://shiny.posit.co/py/api/core/ui.navset_card_pill.html#shiny.ui.navset_card_pill
+    signature: ui.navset_card_pill(*args, id=None, selected=None, title=None, sidebar=None,
+      full_screen=False, header=None, footer=None, placement='above')
   - title: ui.navset_pill
-    href: https://shiny.posit.co/py/api/ui.navset_pill.html
+    href: https://shiny.posit.co/py/api/core/ui.navset_pill.html#shiny.ui.navset_pill
     signature: ui.navset_pill(*args, id=None, selected=None, header=None, footer=None)
-
   - title: ui.navset_pill_list
-    href: https://shiny.posit.co/py/api/ui.navset_pill_list.html
-    signature: ui.navset_pill_list(*args, id=None, selected=None, header=None, footer=None, well=True, widths=(4, 8))
-
+    href: https://shiny.posit.co/py/api/core/ui.navset_pill_list.html#shiny.ui.navset_pill_list
+    signature: ui.navset_pill_list(*args, id=None, selected=None, header=None, footer=None,
+      well=True, widths=(4, 8))
   - title: ui.navset_tab
-    href: https://shiny.posit.co/py/api/ui.navset_tab.html
+    href: https://shiny.posit.co/py/api/core/ui.navset_tab.html#shiny.ui.navset_tab
     signature: ui.navset_tab(*args, id=None, selected=None, header=None, footer=None)
-  - title: ui.update_navs
-    href: https://shiny.posit.co/py/api/ui.update_navs.html
-    signature: ui.update_navs(id, selected=None, session=None)
   - title: ui.update_navset
-    href: https://shiny.posit.co/py/api/ui.update_navset.html
+    href: https://shiny.posit.co/py/api/core/ui.update_navset.html#shiny.ui.update_navset
     signature: ui.update_navset(id, selected=None, session=None)
   - title: ui.nav_control
-    href: https://shiny.posit.co/py/api/ui.nav_control.html
+    href: https://shiny.posit.co/py/api/core/ui.nav_control.html#shiny.ui.nav_control
     signature: ui.nav_control(*args)
   - title: ui.nav_menu
-    href: https://shiny.posit.co/py/api/ui.nav_menu.html
+    href: https://shiny.posit.co/py/api/core/ui.nav_menu.html#shiny.ui.nav_menu
     signature: ui.nav_menu(title, *args, value=None, icon=None, align='left')
   - title: ui.nav_panel
-    href: https://shiny.posit.co/py/api/ui.nav_panel.html
+    href: https://shiny.posit.co/py/api/core/ui.nav_panel.html#shiny.ui.nav_panel
     signature: ui.nav_panel(title, *args, value=None, icon=None)
 ---
 


### PR DESCRIPTION
Closes #405. Supersedes #407 (this is the clean, `main`-based version — #407 was `rc-shiny-v1.7.0`-based and carried the rc commits).

## What

Generates the `title` / `href` / `signature` fields of every `relevant-functions` front-matter block (across `components/**/index.qmd` and `layouts/**/index.qmd`) from the quartodoc-generated `api/core/*.qmd` reference pages, so they can no longer drift from the real `shiny.ui` / `shiny.express.ui` API. Adds a `make` target and a CI check that fails a PR when committed fields are stale (mirrors `test-shinylive-links`).

## How

- **Generate, not lint.** The quartodoc API pages are the single source of truth; a title resolves to its API page's rendered signature block + canonical `…/api/core/…#anchor` href. `title` is never rewritten; a rotted title hard-errors; external `shinywidgets.*` and instance-form `chat.*` entries are skip-listed.
- Fixes existing drift (e.g. `ui.value_box` was missing `min_height`/`id`) and migrates legacy flat hrefs to the direct `core/…#anchor` form.
- Drops the deprecated `ui.update_navs` entry from `layouts/tabs` — it has no API page (superseded by `ui.update_navset`, already listed). Exactly the rot the generator's hard-error is meant to surface.
- `_qmd.py` now emits multi-line front-matter scalars as clean `|` literal blocks (no more mangled `description` fields on layout pages).
- **Falls forward on rot.** The generator has `--strict` / `--no-strict`. The build/setup chain (`components` → `ai-setup`) runs `--no-strict`: an unresolvable (rotted/renamed) title is logged and left as-authored, so it never aborts a local build or `make ai-setup`, while every resolvable entry is still regenerated. CI sets `RELEVANT_FUNCTIONS_STRICT=1` so the same rot fails the check — the correct fields are still required before merge.
- New CI: `.github/workflows/test-relevant-functions.yml`. CLAUDE.md documents running `make components-relevant-functions` after a submodule bump / new component page / API change.
- Quarto version single-sourced from the Makefile via a shared `setup-quarto` action (composed into `setup-py-shiny-site`).
- Also renames the `components-static` make target to `components-static-previews`.

## Base

Based on **`main`** (no rc commits carried). Because `main` does not yet include #404's submodule bump, `ui.card_body` (no API page here) and `ui.panel_well` (dead link removed by #404) are skip-listed for now; remove them from `SKIP_TITLES` once `rc-shiny-v1.7.0` lands on `main`.

## Verification

- 14 unit tests pass (`components/test_relevant_functions.py`).
- Generator is idempotent (working tree stable across runs).
- All non-skip titles resolve against the generated `api/core/**` pages.
- Working tree clean; submodule pointer matches `main` (PR carries no submodule change).

## Done
- [x] Generator + parser (`components/_relevant_functions.py`, `update-relevant-functions.py`)
- [x] `make components-relevant-functions` target (depends on `quartodoc`)
- [x] Regenerated all component/layout pages (drift fixed, hrefs → `core/…#anchor`)
- [x] `_qmd.py` literal-block (`|`) fix for multi-line front-matter scalars
- [x] CI: `test-relevant-functions.yml` + CLAUDE.md guidance
- [x] Generator falls forward on unresolvable titles in build/setup (`--no-strict`); CI stays strict (`RELEVANT_FUNCTIONS_STRICT=1`)
- [x] Rename `components-static` → `components-static-previews`
- [x] Quarto version single-sourced from Makefile via shared `setup-quarto` action
- [x] Discovery/resolution anchored to repo root (CWD-independent)
- [x] Imports consolidated at top of `_relevant_functions.py`
