### PR TITLE
docs(components): add Download Button and Download Link component pages

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -148,6 +148,8 @@ website:
             - components/inputs/dark-mode/index.qmd
             - components/inputs/date-range-selector/index.qmd
             - components/inputs/date-selector/index.qmd
+            - components/inputs/download-button/index.qmd
+            - components/inputs/download-link/index.qmd
             - components/inputs/file/index.qmd
             - components/inputs/numeric-input/index.qmd
             - components/inputs/password-field/index.qmd

--- a/components/inputs/download-button/app-core.py
+++ b/components/inputs/download-button/app-core.py
@@ -1,0 +1,18 @@
+from datetime import date
+
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.download_button("download_data", "Download CSV"),  # <<
+)
+
+
+def server(input, output, session):
+    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+
+app = App(app_ui, server)

--- a/components/inputs/download-button/app-detail-preview.py
+++ b/components/inputs/download-button/app-detail-preview.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.h5("Download example data"),
+    ui.download_button("download_data", "Download CSV"),
+    ui.p("Click the button to download a CSV file generated in memory."),
+)
+
+
+def server(input, output, session):
+    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+
+app = App(app_ui, server)

--- a/components/inputs/download-button/app-express.py
+++ b/components/inputs/download-button/app-express.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+from shiny.express import render
+
+
+@render.download(  # <<
+    filename=lambda: f"data-{date.today().isoformat()}.csv",
+    label="Download CSV",
+)
+def download_data():
+    yield "name,value\n"
+    yield "Alice,100\n"
+    yield "Bob,200\n"

--- a/components/inputs/download-button/app-preview.py
+++ b/components/inputs/download-button/app-preview.py
@@ -1,0 +1,17 @@
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.download_button("download_data", "Download"),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+
+def server(input, output, session):
+    @render.download(filename="data.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+
+app = App(app_ui, server)

--- a/components/inputs/download-button/index.qmd
+++ b/components/inputs/download-button/index.qmd
@@ -1,0 +1,62 @@
+---
+title: Download Button
+sidebar: components
+appPreview:
+  file: components/inputs/download-button/app-preview.py
+  static: true
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/inputs/download-button/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 200
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAEyiooEt5kf1SDCmw5wAOhAmNmyAM4ALLhFxY4AD3QM4s2XxgChyLRFZwGEixAACx0wyytSAdwgAbUlFYAKZMgDEyAA8gRK+vnRcrtSwcAC8rrAARuwodGJg7BRQALQgmXBYFKTsuF4AlFhcsqR0gjAc5QC+WMSyAG7pBKFhCYlwrrHpACLObh6syADCAMoAap0SZRKmdGyj7p4A+plQ5Yjdvrhc-RPp0PAEbVCuAK7iFmAHyEcnyOkAgq5cxHAEAIwABgBYgeTxerlOYAAQqREgQAExAkGSR4QQioCi4dAIFBgKhqChgRoAXSAA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAEyiooEt5kf1SDCmw5wAOhAmNmyAM4ALLhFx8YAocgCCmIg2qs4DIgFcuEiRnQB9U8gC8yUzigBzOFboAbU6wAUE5EDHLixWUgB3CE9SKFYrACNjCgpyfzAwyOjYq3YKKDFCZAKAEQiomNZkAGEAZQA1AoBKImQAYmQAHg6JRvNJCAM6OUMAN0NfJXQkolIkqYoiWThZWS5yRsQAoIABPQHDULKsvzouT2pYODtPWHj2FDoC3KgAWhBcuCwU9lxfRqwuLJSHRBDAOH8AL5YYiyEZNLaBQZsI4VHIcKB-TYQII45C4LhwTyVArQeAEEZQbzicxgBG4-GE4lgTSeLjEOAEACMAAZuWIaXScQyiUUwAAhUjxAgAJl5-MktP6Fkw9i0mF8lhsXEWo0MvQghTAFFw6AQKCNcAAHhQwBCALpAA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.download_button
+    href: https://shiny.posit.co/py/api/core/ui.download_button.html#shiny.ui.download_button
+    signature: ui.download_button(id, label, *, icon=None, width=None, **kwargs)
+  - title: '@render.download'
+    href: https://shiny.posit.co/py/api/core/render.download.html#shiny.render.download
+    signature: render.download(fn=None, *, filename=None, media_type=None, encoding='utf-8',
+      label='Download')
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A download button lets the user download a file from your app when they click it. Use `ui.download_button()` for a button style, or [`ui.download_link()`](../download-link/index.qmd) for a link style.
+
+To add a download button to your app:
+
+  1. Add `ui.download_button()` to the UI with a unique `id` and a descriptive `label`. (In Express mode, `@render.download` automatically places a download button for you, labeled with its `label` argument.)
+
+  2. Define a function with the same name as the button's `id` and decorate it with `@render.download()`.
+
+  3. The download function can either:
+     - Return a string filepath pointing to an existing file on disk.
+     - `yield` the content chunk by chunk (bytes or strings), which lets you generate the file in memory — for example, building a CSV on the fly.
+
+  4. Set the download's filename with the `filename` parameter of `@render.download()`. It accepts a string or a function returning a string, which is useful for dynamic filenames:
+
+     ```python
+     @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+     ```
+
+The `yield` approach streams the file to the browser, so large downloads don't need to be held in memory all at once. For binary content (images, Excel files, etc.), yield `bytes` instead of strings.
+
+See also: [Download Link](../download-link/index.qmd) and [Action Button](../action-button/index.qmd).

--- a/components/inputs/download-button/test_download_button.py
+++ b/components/inputs/download-button/test_download_button.py
@@ -16,7 +16,7 @@ express_app = create_example_fixture(HERE / "app-express.py")
 EXPECTED_CSV = "name,value\nAlice,100\nBob,200\n"
 
 
-def _check_download_button(page: Page, app: ShinyAppProc) -> None:
+def _check_download_button(page: Page, app: ShinyAppProc, tmp_path: Path) -> None:
     page.goto(app.url)
 
     button = controller.DownloadButton(page, "download_data")
@@ -29,12 +29,16 @@ def _check_download_button(page: Page, app: ShinyAppProc) -> None:
     download = download_info.value
 
     assert download.suggested_filename == f"data-{date.today().isoformat()}.csv"
-    assert Path(download.path()).read_text() == EXPECTED_CSV
+    # download.path() is unavailable against a remote browser (CI uses
+    # browser_type.connect()), so save a local copy instead.
+    saved = tmp_path / download.suggested_filename
+    download.save_as(saved)
+    assert saved.read_text() == EXPECTED_CSV
 
 
-def test_download_button_core(page: Page, core_app: ShinyAppProc) -> None:
-    _check_download_button(page, core_app)
+def test_download_button_core(page: Page, core_app: ShinyAppProc, tmp_path: Path) -> None:
+    _check_download_button(page, core_app, tmp_path)
 
 
-def test_download_button_express(page: Page, express_app: ShinyAppProc) -> None:
-    _check_download_button(page, express_app)
+def test_download_button_express(page: Page, express_app: ShinyAppProc, tmp_path: Path) -> None:
+    _check_download_button(page, express_app, tmp_path)

--- a/components/inputs/download-button/test_download_button.py
+++ b/components/inputs/download-button/test_download_button.py
@@ -1,0 +1,40 @@
+import re
+from datetime import date
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+
+from conftest import create_example_fixture
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+HERE = Path(__file__).parent
+
+core_app = create_example_fixture(HERE / "app-core.py")
+express_app = create_example_fixture(HERE / "app-express.py")
+
+EXPECTED_CSV = "name,value\nAlice,100\nBob,200\n"
+
+
+def _check_download_button(page: Page, app: ShinyAppProc) -> None:
+    page.goto(app.url)
+
+    button = controller.DownloadButton(page, "download_data")
+    expect(button.loc).to_contain_text("Download CSV")
+    # The button is disabled until the session registers the download handler.
+    expect(button.loc).not_to_have_class(re.compile(r"\bdisabled\b"))
+
+    with page.expect_download() as download_info:
+        button.loc.click()
+    download = download_info.value
+
+    assert download.suggested_filename == f"data-{date.today().isoformat()}.csv"
+    assert Path(download.path()).read_text() == EXPECTED_CSV
+
+
+def test_download_button_core(page: Page, core_app: ShinyAppProc) -> None:
+    _check_download_button(page, core_app)
+
+
+def test_download_button_express(page: Page, express_app: ShinyAppProc) -> None:
+    _check_download_button(page, express_app)

--- a/components/inputs/download-link/app-core.py
+++ b/components/inputs/download-link/app-core.py
@@ -1,0 +1,18 @@
+from datetime import date
+
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.download_link("download_data", "Download CSV"),  # <<
+)
+
+
+def server(input, output, session):
+    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+
+app = App(app_ui, server)

--- a/components/inputs/download-link/app-detail-preview.py
+++ b/components/inputs/download-link/app-detail-preview.py
@@ -1,0 +1,20 @@
+from datetime import date
+
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.h5("Download example data"),
+    ui.download_link("download_data", "Download CSV"),
+    ui.p("Click the link to download a CSV file generated in memory."),
+)
+
+
+def server(input, output, session):
+    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+
+app = App(app_ui, server)

--- a/components/inputs/download-link/app-express.py
+++ b/components/inputs/download-link/app-express.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+from shiny.express import render, ui
+from shiny.ui import download_link
+
+download_link("download_data", "Download CSV")  # <<
+
+# `@render.download` auto-places a download *button*; wrap it in `ui.hold()`
+# to register the handler without the button, and pair it with the
+# `download_link()` above via the matching id/function name.
+with ui.hold():
+
+    @render.download(filename=lambda: f"data-{date.today().isoformat()}.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"

--- a/components/inputs/download-link/app-preview.py
+++ b/components/inputs/download-link/app-preview.py
@@ -1,0 +1,17 @@
+from shiny import App, render, ui
+
+app_ui = ui.page_fluid(
+    ui.download_link("download_data", "Download"),
+    {"class": "vh-100 d-flex justify-content-center align-items-center px-4"},
+)
+
+
+def server(input, output, session):
+    @render.download(filename="data.csv")
+    def download_data():
+        yield "name,value\n"
+        yield "Alice,100\n"
+        yield "Bob,200\n"
+
+
+app = App(app_ui, server)

--- a/components/inputs/download-link/index.qmd
+++ b/components/inputs/download-link/index.qmd
@@ -1,0 +1,58 @@
+---
+title: Download Link
+sidebar: components
+appPreview:
+  file: components/inputs/download-link/app-preview.py
+  static: true
+listing:
+- id: example
+  template: ../../_partials/components-detail-example.ejs
+  template-params:
+    dir: components/inputs/download-link/
+  contents:
+  - title: Preview
+    file: app-detail-preview.py
+    height: 200
+  - title: Express
+    file: app-express.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAEyiooEt5kf1SDCmw5wAOhAmNmyAM4ALLhFxY4AD3QM4s2XxgChyLRFZwGRAK5cpTFgqUqreg8NakA7hAA2pKKwD6XkoA1hISbp4+foEhABRiYBHevgHsFFAJRAkAIh7JfsgAwgDKAGoJAJTIyADEyAA89WEQdQAGAALGpgxYSVGsrchQFhSkALToXlDE2kNsef3IAFQARiOjEEsA3MjuDBh8wkrIrVZY8qRerLEVrRJ1o0ZwAOZcslQMyBTycMjyUCYvGZdlxvqQRl8fsg1hQNkQAaxkOgoFxPqCQd9IeIWic+ikYhBgjdBlAVqQAG6-clcKBY5AwDjERQQZ58VgAejoFggxG45GQ0HgWAk7lB8mQZwuVxuiGa1WqnWo3V6CxSsToXCBgrgAF4pjAVuwUHQEmkoGMQGk4FhRuxcDcsG9SHRBAyKDcAL5YYiycmVCTythwOjzSL4s0ygOB+W4LhwK7IBLagjkqBeCziMJgKPR5Cx+OIhIAQSCMwIAEYAAyVsRZnPR-MJhIAIVIKwIACZq7XJNmIIRUBRcOgECgwFQ1BQwB6ALpAA
+  - title: Core
+    file: app-core.py
+    shinylive: https://shinylive.io/py/editor/#code=NobwRAdghgtgpmAXAAjFADugdOgnmAGlQGMB7CAFzkqVQDMAnUmZAEyiooEt5kf1SDCmw5wAOhAmNmyAM4ALLhFx8YAocgCCmIg2qs4DIgFcuEiRnQB9U8gC8yUzigBzOFboAbU6wAUE5EDHLixWUgB3CE9SKFYrTyUAa38wMMjo2Kt2CigxQmQ8gBEIqJjWZABhAGUANTyASiJkAGJkAB42iXrzSQgDOjlDADdDXyV0YwoiUkmJqcHZWS5yesQAoIABPT7DUJKMvzouT2pYODtPWAAjdhQ6POyoAFoQbLgsClJ2XF96rC5ZKQ6IIYBxfgBfLDEWRDBrrQL9Nj7MpZDhQX5rCBBbHIXBcOCecp5aDwAhDKDecTmMDwnF4glEsCaBLEOAEACMAAZOWJqbTsfTCQUwAAhUhXAgAJm5vMkNN6Fkw9i0mF8lhsXCIsmGhm6EHyYAouHQCBQhrgAA8KGBwQBdIA
+- id: relevant-functions
+  template: ../../_partials/components-detail-relevant-functions.ejs
+  contents:
+  - title: ui.download_link
+    href: https://shiny.posit.co/py/api/core/ui.download_link.html#shiny.ui.download_link
+    signature: ui.download_link(id, label, *, icon=None, width=None, **kwargs)
+  - title: '@render.download'
+    href: https://shiny.posit.co/py/api/core/render.download.html#shiny.render.download
+    signature: render.download(fn=None, *, filename=None, media_type=None, encoding='utf-8',
+      label='Download')
+---
+
+:::{#example}
+:::
+
+:::{#relevant-functions}
+:::
+
+## Details
+
+A download link lets the user download a file from your app when they click it. It behaves exactly like a [Download Button](../download-button/index.qmd), but renders as an inline link, which fits naturally inside prose or compact layouts.
+
+To add a download link to your app:
+
+  1. Add `ui.download_link()` to the UI with a unique `id` and a descriptive `label`.
+
+  2. Define a function with the same name as the link's `id` and decorate it with `@render.download()`.
+
+  3. The download function can either:
+     - Return a string filepath pointing to an existing file on disk.
+     - `yield` the content chunk by chunk (bytes or strings), which lets you generate the file in memory — for example, building a CSV on the fly.
+
+  4. Set the download's filename with the `filename` parameter of `@render.download()`. It accepts a string or a function returning a string, which is useful for dynamic filenames.
+
+**Express mode:** `@render.download` automatically places a download *button* in the UI. To get a link instead, place `shiny.ui.download_link()` where you want it and register the handler inside `ui.hold()` so the automatic button isn't shown — the link and the handler are paired by the shared `id`/function name, as shown in the Express tab above.
+
+See also: [Download Button](../download-button/index.qmd).

--- a/components/inputs/download-link/test_download_link.py
+++ b/components/inputs/download-link/test_download_link.py
@@ -1,0 +1,40 @@
+import re
+from datetime import date
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+
+from conftest import create_example_fixture
+from shiny.playwright import controller
+from shiny.run import ShinyAppProc
+
+HERE = Path(__file__).parent
+
+core_app = create_example_fixture(HERE / "app-core.py")
+express_app = create_example_fixture(HERE / "app-express.py")
+
+EXPECTED_CSV = "name,value\nAlice,100\nBob,200\n"
+
+
+def _check_download_link(page: Page, app: ShinyAppProc) -> None:
+    page.goto(app.url)
+
+    link = controller.DownloadLink(page, "download_data")
+    expect(link.loc).to_contain_text("Download CSV")
+    # The link is disabled until the session registers the download handler.
+    expect(link.loc).not_to_have_class(re.compile(r"\bdisabled\b"))
+
+    with page.expect_download() as download_info:
+        link.loc.click()
+    download = download_info.value
+
+    assert download.suggested_filename == f"data-{date.today().isoformat()}.csv"
+    assert Path(download.path()).read_text() == EXPECTED_CSV
+
+
+def test_download_link_core(page: Page, core_app: ShinyAppProc) -> None:
+    _check_download_link(page, core_app)
+
+
+def test_download_link_express(page: Page, express_app: ShinyAppProc) -> None:
+    _check_download_link(page, express_app)

--- a/components/inputs/download-link/test_download_link.py
+++ b/components/inputs/download-link/test_download_link.py
@@ -16,7 +16,7 @@ express_app = create_example_fixture(HERE / "app-express.py")
 EXPECTED_CSV = "name,value\nAlice,100\nBob,200\n"
 
 
-def _check_download_link(page: Page, app: ShinyAppProc) -> None:
+def _check_download_link(page: Page, app: ShinyAppProc, tmp_path: Path) -> None:
     page.goto(app.url)
 
     link = controller.DownloadLink(page, "download_data")
@@ -29,12 +29,16 @@ def _check_download_link(page: Page, app: ShinyAppProc) -> None:
     download = download_info.value
 
     assert download.suggested_filename == f"data-{date.today().isoformat()}.csv"
-    assert Path(download.path()).read_text() == EXPECTED_CSV
+    # download.path() is unavailable against a remote browser (CI uses
+    # browser_type.connect()), so save a local copy instead.
+    saved = tmp_path / download.suggested_filename
+    download.save_as(saved)
+    assert saved.read_text() == EXPECTED_CSV
 
 
-def test_download_link_core(page: Page, core_app: ShinyAppProc) -> None:
-    _check_download_link(page, core_app)
+def test_download_link_core(page: Page, core_app: ShinyAppProc, tmp_path: Path) -> None:
+    _check_download_link(page, core_app, tmp_path)
 
 
-def test_download_link_express(page: Page, express_app: ShinyAppProc) -> None:
-    _check_download_link(page, express_app)
+def test_download_link_express(page: Page, express_app: ShinyAppProc, tmp_path: Path) -> None:
+    _check_download_link(page, express_app, tmp_path)

--- a/components/test_ui_api_has_page.py
+++ b/components/test_ui_api_has_page.py
@@ -103,7 +103,7 @@ _MISC = {"busy_indicators", "fill", "hold"}
 # TODO: genuine components that should get their own component page. Move each
 # to a real page (and drop it from here) as pages are written.
 _TODO_NEEDS_COMPONENT_PAGE = {
-    "bind_task_button", "chat_ui", "download_button", "download_link",
+    "bind_task_button", "chat_ui",
     "input_bookmark_button", "input_code_editor", "input_submit_textarea",
     "input_task_button", "output_code", "output_markdown_stream", "output_table",
     "popover", "toast", "toast_header", "show_toast", "hide_toast",


### PR DESCRIPTION
Part of #409.

Adds component pages for the two download controls under **Components > Inputs**:

- `components/inputs/download-button/` — documents `ui.download_button`
- `components/inputs/download-link/` — documents `ui.download_link`

Both pages document the **current stable API on main (shiny 1.6.3)**: `ui.download_button()` / `ui.download_link()` paired with the `@render.download` decorator. The example apps generate a small CSV in memory via `yield`, so they run under shinylive with no filesystem or network assumptions. The download-link Express example uses the `ui.hold()` + `shiny.ui.download_link()` pattern, since 1.6.3's `@render.download` auto-places a *button* in Express mode.

Relationship to other PRs:

- #385 / #386 (schloerke) document the new v1.7.0 `render.download_button` / `render.download_link` API and target the `rc-shiny-v1.7.0` branch. That API does not exist in 1.6.3, so these pages are written against the current API; #385/#386 can rebase onto / update these pages for the v1.7.0 API when the RC lands. Structure and prose here borrow from those PRs.
- #346 (elnelson575) included an earlier download-button page attempt as part of an umbrella PR.

Other changes:

- Registers both pages alphabetically in the `_quarto.yml` inputs sidebar.
- Removes `download_button` / `download_link` from `_TODO_NEEDS_COMPONENT_PAGE` in `components/test_ui_api_has_page.py`.
- Shinylive links and `relevant-functions` fields are generated (`make components-shinylive-links`, `make components-relevant-functions`); `make components-static-previews` renders both preview cards.

Testing:

- New Playwright interaction tests (`test_download_button.py`, `test_download_link.py`) drive the Core AND Express apps with `controller.DownloadButton` / `controller.DownloadLink`, click the control, and assert the downloaded file's suggested filename and exact CSV content via `page.expect_download()` — 4 passed.
- `uv run pytest components/test_examples_smoke.py -k "download-button or download-link" -n0` — 8 passed (all 8 new example apps).
- `uv run pytest components/test_ui_api_has_page.py -n0` — 4 passed.
- Both pages render cleanly with `quarto render`.
