### PR TITLE
docs: A few small tweaks from a doc readthrough

### DIFF
--- a/get-started/debug.qmd
+++ b/get-started/debug.qmd
@@ -206,7 +206,7 @@ If your Shiny application is running with [Shinylive (Python in the browser)](sh
 
 ### Shiny
 
-  1. The first place to look for help with Shiny is [Posit Community](https://community.rstudio.com/c/shiny){target="_blank"}, which is a warm and welcoming place to ask any questions you might have about Shiny (as well as tidyverse and all things Posit). The web site is running Discourse, which is an excellent community discussion platform. Our developers monitor Posit Community and answer questions periodically.
+  1. The first place to look for help with Shiny is [Posit Community](https://forum.posit.co/c/shiny){target="_blank"}, which is a warm and welcoming place to ask any questions you might have about Shiny (as well as tidyverse and all things Posit). The web site is running Discourse, which is an excellent community discussion platform. Our developers monitor Posit Community and answer questions periodically.
 
   2. Shiny users (and the Shiny team!) regularly talk on [Shiny's Discord server](https://discord.gg/yMGCamUMnS){target="_blank"}. Discord has more of a chat interface than Posit Community, and is not indexed by search engines. It's a great forum for casual conversations or networking with other Shiny developers.
 
@@ -215,11 +215,19 @@ If your Shiny application is running with [Shinylive (Python in the browser)](sh
 ### Posit Connect Cloud
 
   1. For information about [Posit Connect Cloud](https://connect.posit.cloud/), see the [Connect Cloud Documentation](https://docs.posit.co/connect-cloud/){target="_blank"}
+
   2. For community support, there is a [community forum for Connect Cloud](https://forum.posit.co/c/posit-professional-hosted/posit-connect-cloud/67){target="_blank"}.
 
   3. Customers with Starter, Basic, Standard or Pro subscriptions can get direct access to our support engineers by opening a case on [the Posit Support site](https://support.posit.co/){target="_blank"}. Questions are answered from 9AM - 5PM(EST) Monday - Friday.
 
-### shinyapps.io
+### Shinyapps.io
+
+::: callout-tip
+# shinyapps.io migration
+
+shinyapps.io is being sunsetted in favor of Connect Cloud in 2027 (see the [blog post](https://posit.co/blog/migrating-connect-cloud-posits-unified-publishing-solution) and
+[migration documentation](https://docs.posit.co/shinyapps.io/guide/migration/){target="_blank"} for more details).
+:::
 
   1. For documentation and instructions on how to use [shinyapps.io](http://shinyapps.io){target="_blank"}, see the [shinyapps.io user guide](https://docs.posit.co/shinyapps.io/){target="_blank"}.
 

--- a/get-started/deploy-cloud.qmd
+++ b/get-started/deploy-cloud.qmd
@@ -18,6 +18,13 @@ To get started, sign up for [Connect Cloud](https://connect.posit.cloud/), revie
 
 ## Shinyapps.io
 
+::: callout-tip
+# shinyapps.io migration
+
+shinyapps.io is being sunsetted in favor of Connect Cloud in 2027 (see the [blog post](https://posit.co/blog/migrating-connect-cloud-posits-unified-publishing-solution) and
+[migration documentation](https://docs.posit.co/shinyapps.io/guide/migration/){target="_blank"} for more details). We recommend using Connect Cloud (see above) instead.
+:::
+
 [shinyapps.io](https://www.shinyapps.io/) also allows you to easily host applications without having to set up your own server, and has a variety of free and paid plans depending on your use case.
 
 To use shinyapps.io, follow these steps:

--- a/get-started/deploy-on-prem.qmd
+++ b/get-started/deploy-on-prem.qmd
@@ -68,7 +68,7 @@ If you want to read more about our commitment to free and open source software, 
 [Shiny Server](https://posit.co/products/open-source/shinyserver/) is an open source server written in Node.js that can host multiple Shiny apps on a single port, managing the starting/stopping/restarting of each app's Python process.
 
 -   Shiny Server v1.5.22 or later is required for Shiny for Python apps.
-    You can find [the latest version of Shiny Server here](https://posit.co/download/shiny-server/).
+    You can find the latest version of Shiny Server [here](https://github.com/rstudio/shiny-server).
 -   Linux only (see [Platform Support](https://posit.co/about/platform-support/) for a list of supported distributions).
 
 Compared to Posit Connect, deploying apps on Shiny Server is less automated and more config-file based, similar in spirit to Apache or nginx.

--- a/get-started/index.qmd
+++ b/get-started/index.qmd
@@ -216,7 +216,7 @@ Shiny for Python empowers you to bring your data to life with interactive applic
   Build delightful user interfaces using an extensive library of simple yet composable [components](/components/) and [layouts](/layouts/).
   As your app grows, you'll also appreciate advanced features like [modules](/docs/modules.qmd), [theming](/docs/ui-customize.qmd), [non-blocking tasks](/docs/nonblocking.qmd), [bookmarking](https://shiny.posit.co/blog/posts/shiny-python-1.4/), and more.
 
-- **Ready for AI**<br>
+- **Easily integrate AI into your applications**<br>
   Quickly build [beautiful AI apps](/docs/genai-inspiration.qmd) like [chatbots](/docs/genai-chatbots.qmd) and other [streaming](/docs/genai-stream.qmd) interfaces.
 
 


### PR DESCRIPTION
Small suggestions from reviewing py-shiny docs:

1. Changes the "Why Shiny?" bullet heading on the Get Started page from **Ready for AI** to **Easily integrate AI into your applications**, which states the benefit more directly. Only the bullet heading changes; the supporting sentence and its links are untouched.
2. Add notes about sunsetting of `shinyapps.io`
3. Fix a broken link for shiny-server