### PR TITLE
chore: Update to py-shiny v1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter
 jupyter_client < 8.0.0
 tabulate
-shinylive==0.8.9
+shinylive==0.8.11
 # Pinned to <2.0.0 due to compatibility issues with quartodoc
 # See: https://github.com/posit-dev/py-shiny/commit/c2e4b204
 griffe>=1.3.2,<2.0.0


### PR DESCRIPTION
Docs-site update for the [py-shiny v1.7.0](https://github.com/posit-dev/py-shiny/releases/tag/v1.7.0) release train (Phase 10).

## Changes

- `py-shiny` submodule: `v1.6.3` → **`v1.7.0`**
- `requirements.txt`: `shinylive==0.8.9` → **`shinylive==0.8.11`**

## Note on how far behind these were

Both were more than one release stale, so this PR spans more than 1.7.0:

- The submodule sat at **v1.6.3**, so the site was also missing **v1.6.4** — the security patch for the bookmark-restore path-traversal fix. That content lands here too.
- `shinylive` was pinned at **0.8.9** (assets 0.10.12), two package releases back. 0.8.11 pins the [v0.10.14](https://github.com/posit-dev/shinylive/releases/tag/v0.10.14) assets, which bundle shiny 1.7.0 and shinyswatch 0.12.0, so the embedded editors will now run 1.7.0 rather than 1.6.2-era code.

## Review focus for the deploy preview

Worth a look at the pages covering what 1.7.0 added or changed:

- **New API reference pages** — `ui.offcanvas()` / `show_offcanvas()` / `hide_offcanvas()` / `toggle_offcanvas()`, `@render.download_button`, `@render.download_link`, and the `shiny.testmode` module.
- **Deprecation rendering** — `@render.download` is now deprecated; its page should say so and point at the replacements.
- **Embedded shinylive examples** — these now execute shiny 1.7.0 in the browser. The `offcanvas` examples are the ones that would previously have rendered unstyled, since shinyswatch's pre-built themes only picked up the Offcanvas SCSS in 0.12.0.

I have not run the preview build myself; the versions above are verified, but the rendered output needs eyes before merge.

Part of the py-shiny v1.7.0 release train; see posit-dev/py-shiny#2377.