### PR TITLE
ci: add done-test-apps and done-test-smoke aggregate checks

### DIFF
--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -38,3 +38,22 @@ jobs:
       # no-ops because the remote server env is set above).
       - name: Run per-component app tests (shard ${{ matrix.shard }} of 6)
         run: make test-apps PYTEST_ARGS="--num-shards 6 --shard-id ${{ matrix.shard }}"
+
+  # Single stable check for branch protection / auto-merge. The `apps` matrix
+  # above may be re-sharded freely without touching the required-checks list.
+  done-test-apps:
+    name: done-test-apps
+    # `always()` is required: without it, a failing shard would make this job
+    # skip, and GitHub treats a skipped required check as satisfied.
+    if: always()
+    needs: apps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify that every apps shard succeeded
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "Job results: $RESULTS"
+          if echo "$RESULTS" | grep -qE 'failure|cancelled|skipped'; then
+            exit 1
+          fi

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -43,3 +43,22 @@ jobs:
       # no-ops because the remote server env is set above).
       - name: Smoke-test shard ${{ matrix.shard }} of 6
         run: make test-smoke PYTEST_ARGS="--num-shards 6 --shard-id ${{ matrix.shard }}"
+
+  # Single stable check for branch protection / auto-merge. The `smoke` matrix
+  # above may be re-sharded freely without touching the required-checks list.
+  done-test-smoke:
+    name: done-test-smoke
+    # `always()` is required: without it, a failing shard would make this job
+    # skip, and GitHub treats a skipped required check as satisfied.
+    if: always()
+    needs: smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify that every smoke shard succeeded
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "Job results: $RESULTS"
+          if echo "$RESULTS" | grep -qE 'failure|cancelled|skipped'; then
+            exit 1
+          fi


### PR DESCRIPTION
Adds one aggregate job per sharded test workflow so there is a **single stable check name** to mark as required in branch protection:

- `done-test-apps` — aggregates the 6 `apps` shards in `test-apps.yml`
- `done-test-smoke` — aggregates the 6 `smoke` shards in `test-smoke.yml`

Modeled on py-shiny's [`pr-gate`](https://github.com/posit-dev/py-shiny/blob/67fc0f450b142c3976dc8b7949c7d14e802a6624/.github/workflows/pytest.yaml#L419-L449).

## Why

Both workflows run as 6-shard matrices, so requiring them today means listing `apps (0)`…`apps (5)` and `smoke (0)`…`smoke (5)` individually. Any change to the shard count renames the checks, and the required-checks list silently keeps pointing at jobs that no longer exist — which reads as "green" rather than erroring. With these jobs you require two names and can re-shard freely.

## Two subtleties worth calling out

1. **`if: always()` is load-bearing.** Without it, a failing shard causes the aggregate job to *skip*, and GitHub treats a skipped required check as **satisfied**. The gate would pass exactly when it should fail.
2. **`skipped` and `cancelled` count as failures**, not just `failure`, for the same reason.

Verified the aggregation branch-by-branch:

| `needs.*.result` | outcome |
|---|---|
| `[ "success" ]` | exit 0 |
| `[ "failure" ]` | exit 1 |
| `[ "cancelled" ]` | exit 1 |
| `[ "skipped" ]` | exit 1 |

Both files parse as valid YAML and the new jobs resolve `needs: apps` / `needs: smoke` respectively.

## After merging

Add `done-test-apps` and `done-test-smoke` to the branch-protection required checks, and remove the individual `apps (N)` / `smoke (N)` entries if any are listed.