### PR TITLE
ci: fold merge back into deploy and gate done-site on it

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -141,8 +141,16 @@ jobs:
           # use branch name, but replace slashes. E.g. feat/a -> feat-a
           echo "RELEASE_NAME=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
 
+      # Non-fatal: `done-site` does not wait for this job, so an auto-merging PR
+      # can be squashed and its branch deleted while this job is still running,
+      # and creating a deployment for the vanished ref then fails with HTTP 422.
+      # The button is cosmetic -- losing it must not take the Netlify deploy
+      # with it. Downstream steps therefore avoid this step's outputs, and the
+      # guard below tests `outcome` (the real result) rather than `conclusion`
+      # (which `continue-on-error` forces to "success").
       - name: Create Github "view deployment" button in PR
         if: ${{github.event_name == 'pull_request'}}
+        continue-on-error: true
         uses: ./.github/internal/deployment-start
         id: deployment
         with:
@@ -156,7 +164,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
-          ALIAS: ${{ steps.deployment.outputs.env }}
+          ALIAS: ${{ env.RELEASE_NAME }}
         run: |
           npm install -g netlify-cli@26.1.0
           # push main branch to production, others to preview --
@@ -168,12 +176,12 @@ jobs:
 
       - name: Update Github "view deployment" button in PR
         uses: ./.github/internal/deployment-finish
-        if: ${{ steps.deployment.conclusion != 'failure' && github.event_name == 'pull_request'}}
+        if: ${{ steps.deployment.outcome == 'success' && github.event_name == 'pull_request'}}
         with:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          environment: ${{ steps.deployment.outputs.env }}
+          environment: ${{ env.RELEASE_NAME }}
           status: ${{ job.status }}
-          environment_url: "https://${{ steps.deployment.outputs.env }}--pyshiny.netlify.app"
+          environment_url: "https://${{ env.RELEASE_NAME }}--pyshiny.netlify.app"
           token: ${{ secrets.GITHUB_TOKEN }}
           log_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -78,17 +78,22 @@ jobs:
           path: .quarto/shinylive-cache
           key: shinylive-cache-${{ hashFiles('requirements.txt') }}-${{ github.run_id }}-${{ matrix.shard }}
 
-  # Assembles the shard artifacts into the whole site. Split out from `publish`
-  # so that `done-site` can gate on `scripts/ci-merge.py`: this job uses no
-  # secrets and needs no elevated token, so unlike `publish` it also succeeds on
-  # pull requests from forks.
+  # Merges the shard artifacts into a whole site, then publishes it to Netlify.
+  #
+  # `done-site` gates on this job, so every step here must be able to succeed on
+  # a pull request from a fork -- otherwise outside contributions could never
+  # merge. Fork PRs get neither the Netlify secrets nor a writable GITHUB_TOKEN,
+  # so the publishing steps below are skipped there (see PR #420, which failed
+  # with HTTP 403 before this guard existed). The merge itself needs no secrets
+  # and always runs, which is the part worth gating on.
   #
   # No `if: always()` here on purpose -- a failing shard *should* skip this
-  # rather than assemble a knowingly incomplete site. `done-site` treats that
-  # skip as a failure.
-  merge:
+  # rather than publish a broken site. `done-site` treats that skip as a failure.
+  deploy:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -97,33 +102,6 @@ jobs:
           path: _shards/
       - name: Merge shards
         run: python3 scripts/ci-merge.py --shards _shards --out _build
-
-      # Hand the assembled site to `publish` so that what gets deployed is
-      # byte-for-byte what was gated here.
-      - uses: actions/upload-artifact@v7
-        with:
-          name: site-merged
-          path: _build/
-          include-hidden-files: true
-          retention-days: 1
-
-  # Publishes the assembled site to Netlify and manages the PR "view deployment"
-  # button.
-  #
-  # Never mark this a required check, and never add it to `done-site`'s `needs`:
-  # it uses Netlify secrets and `deployments: write`, and `pull_request` runs
-  # from forks get a read-only GITHUB_TOKEN, so it fails with HTTP 403 there no
-  # matter how healthy the site is. Gating on it blocks all outside
-  # contributions (see PR #420).
-  publish:
-    needs: merge
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          name: site-merged
-          path: _build/
 
       # =====================================================
       # Deploy docs to Netlify
@@ -149,7 +127,7 @@ jobs:
       # guard below tests `outcome` (the real result) rather than `conclusion`
       # (which `continue-on-error` forces to "success").
       - name: Create Github "view deployment" button in PR
-        if: ${{github.event_name == 'pull_request'}}
+        if: ${{ github.event_name == 'pull_request' && env.IS_FORK != 'true' }}
         continue-on-error: true
         uses: ./.github/internal/deployment-start
         id: deployment
@@ -160,6 +138,7 @@ jobs:
           log_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Deploy to Netlify
+        if: ${{ env.IS_FORK != 'true' }}
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -176,7 +155,7 @@ jobs:
 
       - name: Update Github "view deployment" button in PR
         uses: ./.github/internal/deployment-finish
-        if: ${{ steps.deployment.outcome == 'success' && github.event_name == 'pull_request'}}
+        if: ${{ steps.deployment.outcome == 'success' && github.event_name == 'pull_request' && env.IS_FORK != 'true' }}
         with:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           environment: ${{ env.RELEASE_NAME }}
@@ -193,14 +172,16 @@ jobs:
   # and GitHub reports a skipped job as "Success" even when it is a required
   # check.
   #
-  # `publish` is deliberately NOT in `needs` -- see the comment on that job.
+  # `deploy` is in `needs` only because its fork-hostile steps are guarded --
+  # see the comment on that job. Removing those guards would make every fork
+  # pull request permanently unmergeable.
   done-site:
     name: done-site
     if: always()
-    needs: [build, merge]
+    needs: [build, deploy]
     runs-on: ubuntu-latest
     steps:
-      - name: Verify that every shard built and the site assembled
+      - name: Verify that every shard built and the site deployed
         env:
           RESULTS: ${{ toJSON(needs.*.result) }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Full renders are split into weight-balanced slices and merged:
   concatenates the shard-scoped `search.json`/`llms.txt`, keeps the real
   homepage over per-shard redirect stubs, and rewrites residual cross-shard
   `.qmd` hrefs to `.html`.
-- CI runs 10 shard jobs + `merge` + `publish`; `make site-parallel` does the
+- CI runs 10 shard jobs + a merge/deploy job; `make site-parallel` does the
   same locally in APFS clone-copy scratch trees (`SHARDS=6` default).
 - Known cosmetic gap: navbar section-highlight is missing on ~38 pages whose
   navbar target renders in another shard.
@@ -257,9 +257,9 @@ All code examples use Shinylive to run Python in the browser via WebAssembly. Th
 
 - **Production:** Commits to `main` branch trigger automatic build and deploy via GitHub Actions
 - **Preview:** Pull requests generate preview deployments (e.g., `pr-123--pyshiny.netlify.app`)
-- **Pipeline:** 10 parallel shard jobs render slices of the site, then `merge` assembles the artifacts (`scripts/ci-merge.py`) and `publish` pushes the result to Netlify — ~9 min end to end. A failed shard skips both. Superseded runs are cancelled by a concurrency group (only the newest commit per ref deploys).
-- **Merge gating:** `done-site` is the only `site.yml` job in the required-checks list. It is an `if: always()` aggregator over `[build, merge]` that fails on any `failure|cancelled|skipped` result, so the shard count can change without touching branch protection. The `always()` matters: a job with a plain `needs:` *skips* when an upstream job fails, and GitHub reports a skipped job as "Success" even when required — `done-site` turns that silent pass into a hard failure.
-- **Why `merge` and `publish` are separate jobs:** so the merge can be gated and the publish cannot. `publish` uses Netlify secrets and `deployments: write`, and `pull_request` runs from forks get a read-only `GITHUB_TOKEN`, so it fails with HTTP 403 on any outside contribution regardless of site health (see PR #420). Adding `publish` to `done-site`'s `needs` — or to the required-checks list — would permanently block external contributors. `merge` uses no secrets, so it is safe to gate on.
+- **Pipeline:** 10 parallel shard jobs render slices of the site, then a `deploy` job merges the artifacts (`scripts/ci-merge.py`) and pushes the result to Netlify — ~9 min end to end. A failed shard skips the deploy. Superseded runs are cancelled by a concurrency group (only the newest commit per ref deploys).
+- **Merge gating:** `done-site` is the only `site.yml` job in the required-checks list. It is an `if: always()` aggregator over `[build, deploy]` that fails on any `failure|cancelled|skipped` result, so the shard count can change without touching branch protection. The `always()` matters: a job with a plain `needs:` *skips* when an upstream job fails, and GitHub reports a skipped job as "Success" even when required — `done-site` turns that silent pass into a hard failure.
+- **`deploy` must stay fork-safe:** `done-site` gates on `deploy`, so any step in `deploy` that a fork PR cannot pass would make outside contributions permanently unmergeable. Fork PRs get neither the Netlify secrets nor a writable `GITHUB_TOKEN`, so the publishing steps are guarded with `env.IS_FORK != 'true'`; PR #420 failed with HTTP 403 before that guard existed. The `ci-merge.py` step needs no secrets and always runs. The cosmetic "view deployment" button is additionally `continue-on-error: true` — both historical `deploy` failures (#417, #420) were in that step, and a flaky button must not block merges.
 - **Escape hatch:** run the workflow manually (`workflow_dispatch`) with `full_render = true` for a single unsharded build job.
 - **CI caches:** `.quarto/shinylive-cache/` persists across runs via `actions/cache` (content-addressed keys; safe to restore stale).
 - **Platform:** Hosted on Netlify


### PR DESCRIPTION
Follow-up to #433. Simplifies the job graph and closes the `ci-merge.py` gating gap at the same time.

## Before / after

```
#433:   build ── merge ── publish          done-site: needs [build, merge]
this:   build ── deploy                    done-site: needs [build, deploy]
```

`merge` and `publish` fold back into one `deploy` job, and `done-site` gates on it. The `site-merged` artifact round-trip goes away — unnecessary once the two share a workspace.

## The catch, and the guard

`done-site` gating on `deploy` means **every step in `deploy` must be passable by a fork PR**, or outside contributions can never merge. They currently cannot: fork PRs get neither the Netlify secrets nor a writable `GITHUB_TOKEN`. PR #420 (jat255) died exactly there:

```
success  Merge shards                              <- fine
failure  Create Github "view deployment" button    <- gh: Resource not accessible
skipped  Deploy to Netlify                            by integration (HTTP 403)
```

So the publishing steps are now skipped on forks:

```yaml
env:
  IS_FORK: ${{ github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name != github.repository }}
```

`Merge shards` needs no secrets and runs everywhere — which is the part worth gating on. Fork PRs get no preview deploy (they never could), but `deploy` succeeds and they stay mergeable.

## Keeping the deployment button non-fatal

`continue-on-error: true` stays on the "view deployment" button step, and matters more now than in the previous revision: with `done-site` waiting on `deploy`, anything that fails here blocks merges. Both historical `deploy` failures were in precisely that step:

- #417 (internal) — `digest-mismatch`, an action-resolution problem
- #420 (fork) — HTTP 403

Neither says anything about whether the site is good. The button is cosmetic; it must not gate merges.

The completion guard tests `steps.deployment.outcome == 'success'` rather than `conclusion != 'failure'` — `continue-on-error` forces `conclusion` to `"success"`, so the old guard would run the finish step with an empty `deployment_id`.

## Accepted tradeoff

A genuine Netlify outage now blocks merges, where in #433 it did not. That is the price of gating `ci-merge.py` in a single job, and it is deliberate — the two failure modes we have actually seen are both neutralised above.

## Side effect worth knowing

`done-site` now waits for `deploy`, so an auto-merging PR can no longer be squashed mid-deploy. That removes the HTTP 422 race that broke the run which merged #433 (`gh: No ref found for: schloerke/fix-issue-431`).