### PR TITLE
docs: document resolve_id() and current_namespace() on the modules page

### DIFF
--- a/docs/modules.qmd
+++ b/docs/modules.qmd
@@ -423,16 +423,18 @@ Since modules allow you to tie UI and Server code together in the same namespace
 Anything that you can do in a Shiny app can also be done inside of a module, and modules can themselves call other modules.
 This allows you to break your app up into building blocks of various sizes, compose those blocks to build different applications, and share them with others.
 
-## Namespacing ids in custom HTML
+## Namespacing IDs in custom HTML
 
-Shiny's own UI functions take care of namespacing for you.
-Call `ui.input_text("text_in", "Enter text")` inside a module whose id is `row_1`, and the id that reaches the browser is `row_1-text_in`.
+Shiny's UI functions handle namespacing for you. If you call `ui.input_text("text_in", "Enter text")`
+inside a module with the id `row_1`, the ID that reaches the browser is `row_1-text_in`.
 
-It's worth being precise about *where* that happens, because it explains a behavior that otherwise looks like a bug.
-The `@module.ui` decorator does not rewrite the UI that your function returns.
-All it does is set the *current namespace* for the duration of the call; it is each individual `ui.input_*()` and `ui.output_*()` function that looks up that namespace and prefixes its own id with it.
+It's worth going into some detail about how that happens, because it explains a behavior which might look like
+a bug at first glance. The `@module.ui` decorator does not modify the UI that your function returns.
+Instead, it sets the current namespace while the function runs, and then each `ui.input_*()` and
+`ui.output_*()` function looks up that namespace and adds it as a prefix to its own ID.
 
-So an id that you write by hand — on `ui.div()`, or on any other raw HTML tag — comes out unchanged, because no Shiny UI function was involved to namespace it:
+This means that an ID you write by hand, such as one you pass to `ui.div()` or to any other raw HTML tag,
+comes out unchanged, because no Shiny UI function was involved to namespace it.
 
 ```{.python}
 from shiny import module, ui
@@ -445,7 +447,8 @@ print(modui("modid"))
 #> <div id="divid"></div>
 ```
 
-To namespace such an id yourself, pass it through `resolve_id()`, which applies the current namespace exactly the way Shiny's UI functions do:
+To namespace an ID like this yourself, pass it to `resolve_id()`, which applies the current namespace the
+same way Shiny's UI functions do.
 
 ```{.python}
 from shiny import module, ui
@@ -459,16 +462,14 @@ print(modui("modid"))
 #> <div id="modid-divid"></div>
 ```
 
-::: callout-tip
-### Rule of thumb
+In general, if Shiny generated the ID then it is already namespaced, and if you wrote the ID yourself then it
+needs `resolve_id()`.
 
-If Shiny generated the id, it is already namespaced. If you typed the id yourself, wrap it in `resolve_id()`.
-:::
-
-This matters whenever something else has to find that element by its id: your own CSS or JavaScript, or a Shiny function that takes a CSS selector, such as `ui.insert_ui()`.
-In the app below, each module instance owns a `notes` container that its server logic inserts into.
-Because both the id and the selector go through `resolve_id()`, each instance's notes land in its own container.
-Without it, both instances would emit a `<div id="notes">` and every note would be inserted into the first one.
+This matters any time something else needs to find the element by its ID, whether that's your own CSS or JavaScript,
+or a Shiny function which takes a CSS selector, like `ui.insert_ui()`. In the app below, each module instance has its own
+`notes` container that its server function inserts into. Both the ID and the selector are passed through `resolve_id()`,
+so each instance's notes go into its own container. Without it, both instances would create a `<div id="notes">`, and
+every note would be inserted into the first one.
 
 ::: {.panel-tabset .panel-pills}
 
@@ -488,7 +489,7 @@ from shiny.module import resolve_id
 def note_row(input, output, session):
     with ui.card():
         ui.input_action_button("add", "Add a note")
-        # A hand-written id, so it needs resolve_id() to be namespaced
+        # A hand-written ID, so it needs resolve_id() to be namespaced
         ui.div(id=resolve_id("notes"))
 
     @reactive.effect
@@ -497,7 +498,7 @@ def note_row(input, output, session):
         ui.insert_ui(
             ui.tags.p(f"Note {input.add()}"),
             # resolve_id() works in the server function too
-            selector="#" + resolve_id("notes"),
+            selector=f"#{resolve_id('notes')}",
             where="beforeEnd",
         )
 
@@ -522,7 +523,7 @@ from shiny.module import resolve_id
 def note_row_ui():
     return ui.card(
         ui.input_action_button("add", "Add a note"),
-        # A hand-written id, so it needs resolve_id() to be namespaced
+        # A hand-written ID, so it needs resolve_id() to be namespaced
         ui.div(id=resolve_id("notes")),
     )
 
@@ -535,7 +536,7 @@ def note_row_server(input, output, session):
         ui.insert_ui(
             ui.p(f"Note {input.add()}"),
             # resolve_id() works in the server function too
-            selector="#" + resolve_id("notes"),
+            selector=f"#{resolve_id('notes')}",
             where="beforeEnd",
         )
 
@@ -557,8 +558,8 @@ app = App(app_ui, server)
 
 :::
 
-`resolve_id()` is also what makes a custom component module-aware, since the component's own HTML is written by hand.
-For a longer example of that, see [Custom JavaScript component](custom-component-one-off.qmd).
+The same applies when you write a custom component, since the component's HTML is written by hand.
+For a longer example, see [Custom JavaScript component](custom-component-one-off.qmd).
 
 ## Getting the current module id
 

--- a/docs/modules.qmd
+++ b/docs/modules.qmd
@@ -423,6 +423,143 @@ Since modules allow you to tie UI and Server code together in the same namespace
 Anything that you can do in a Shiny app can also be done inside of a module, and modules can themselves call other modules.
 This allows you to break your app up into building blocks of various sizes, compose those blocks to build different applications, and share them with others.
 
+## Namespacing ids in custom HTML
+
+Shiny's own UI functions take care of namespacing for you.
+Call `ui.input_text("text_in", "Enter text")` inside a module whose id is `row_1`, and the id that reaches the browser is `row_1-text_in`.
+
+It's worth being precise about *where* that happens, because it explains a behavior that otherwise looks like a bug.
+The `@module.ui` decorator does not rewrite the UI that your function returns.
+All it does is set the *current namespace* for the duration of the call; it is each individual `ui.input_*()` and `ui.output_*()` function that looks up that namespace and prefixes its own id with it.
+
+So an id that you write by hand — on `ui.div()`, or on any other raw HTML tag — comes out unchanged, because no Shiny UI function was involved to namespace it:
+
+```{.python}
+from shiny import module, ui
+
+@module.ui
+def modui():
+    return ui.div(id="divid")
+
+print(modui("modid"))
+#> <div id="divid"></div>
+```
+
+To namespace such an id yourself, pass it through `resolve_id()`, which applies the current namespace exactly the way Shiny's UI functions do:
+
+```{.python}
+from shiny import module, ui
+from shiny.module import resolve_id
+
+@module.ui
+def modui():
+    return ui.div(id=resolve_id("divid"))
+
+print(modui("modid"))
+#> <div id="modid-divid"></div>
+```
+
+::: callout-tip
+### Rule of thumb
+
+If Shiny generated the id, it is already namespaced. If you typed the id yourself, wrap it in `resolve_id()`.
+:::
+
+This matters whenever something else has to find that element by its id: your own CSS or JavaScript, or a Shiny function that takes a CSS selector, such as `ui.insert_ui()`.
+In the app below, each module instance owns a `notes` container that its server logic inserts into.
+Because both the id and the selector go through `resolve_id()`, each instance's notes land in its own container.
+Without it, both instances would emit a `<div id="notes">` and every note would be inserted into the first one.
+
+::: {.panel-tabset .panel-pills}
+
+### Express
+
+::: {.column-page}
+```{shinylive-python}
+#| standalone: true
+#| components: [editor, viewer]
+## file: app.py
+from shiny import reactive
+from shiny.express import module, ui
+from shiny.module import resolve_id
+
+
+@module
+def note_row(input, output, session):
+    with ui.card():
+        ui.input_action_button("add", "Add a note")
+        # A hand-written id, so it needs resolve_id() to be namespaced
+        ui.div(id=resolve_id("notes"))
+
+    @reactive.effect
+    @reactive.event(input.add)
+    def _():
+        ui.insert_ui(
+            ui.tags.p(f"Note {input.add()}"),
+            # resolve_id() works in the server function too
+            selector="#" + resolve_id("notes"),
+            where="beforeEnd",
+        )
+
+
+note_row("row_1")
+note_row("row_2")
+```
+:::
+
+### Core
+
+::: {.column-page}
+```{shinylive-python}
+#| standalone: true
+#| components: [editor, viewer]
+## file: app.py
+from shiny import App, module, reactive, ui
+from shiny.module import resolve_id
+
+
+@module.ui
+def note_row_ui():
+    return ui.card(
+        ui.input_action_button("add", "Add a note"),
+        # A hand-written id, so it needs resolve_id() to be namespaced
+        ui.div(id=resolve_id("notes")),
+    )
+
+
+@module.server
+def note_row_server(input, output, session):
+    @reactive.effect
+    @reactive.event(input.add)
+    def _():
+        ui.insert_ui(
+            ui.p(f"Note {input.add()}"),
+            # resolve_id() works in the server function too
+            selector="#" + resolve_id("notes"),
+            where="beforeEnd",
+        )
+
+
+app_ui = ui.page_fluid(
+    note_row_ui("row_1"),
+    note_row_ui("row_2"),
+)
+
+
+def server(input, output, session):
+    note_row_server("row_1")
+    note_row_server("row_2")
+
+
+app = App(app_ui, server)
+```
+:::
+
+:::
+
+`resolve_id()` is also what makes a custom component module-aware, since the component's own HTML is written by hand.
+For a longer example of that, see [Custom JavaScript component](custom-component-one-off.qmd).
+
 ## Conclusion
 
 Whenever you find that your Shiny code is repetitive, you should consider whether it's worth extracting some logic into a function or a module.

--- a/docs/modules.qmd
+++ b/docs/modules.qmd
@@ -560,6 +560,122 @@ app = App(app_ui, server)
 `resolve_id()` is also what makes a custom component module-aware, since the component's own HTML is written by hand.
 For a longer example of that, see [Custom JavaScript component](custom-component-one-off.qmd).
 
+## Getting the current module id
+
+A module function does not receive its own id as an argument: `@module.ui` and `@module.server` consume the id you pass and turn it into the namespace.
+So if a module's behavior needs to depend on its own id, it's tempting to add a parameter for it and pass the id in twice, as in `row_ui("row_1", "row_1")`.
+You don't have to. Call `current_namespace()` inside the module instead:
+
+```{.python}
+from shiny import module
+from shiny.module import current_namespace
+
+@module.ui
+def row_ui():
+    module_id = current_namespace()
+    ...
+```
+
+A few things to know about the value it returns:
+
+- It is the *fully resolved* namespace, meaning the id you passed prefixed by the namespaces of any enclosing modules. A top-level `row_ui("row_1")` sees `"row_1"`, but a `row_ui("inner")` called inside a module that was created as `outer_ui("out")` sees `"out-inner"`.
+- It is a `str` subclass, so ordinary string methods work on it.
+- It works in module server functions as well as module UI functions.
+- Outside of any module it returns an empty string, since the top level of an app has no namespace.
+
+In the app below, the label a row uses depends on its own id, and the row's output reports which row it belongs to — neither of which requires threading the id through an extra parameter.
+
+::: {.panel-tabset .panel-pills}
+
+### Express
+
+::: {.column-page}
+```{shinylive-python}
+#| standalone: true
+#| components: [editor, viewer]
+## file: app.py
+from shiny.express import module, render, ui
+from shiny.module import current_namespace
+
+
+@module
+def io_row(input, output, session):
+    # The module's own id, without having to pass it in a second time
+    module_id = current_namespace()
+    is_special = module_id.endswith(("3", "5"))
+    label = "Enter something special" if is_special else "Enter text"
+
+    with ui.layout_columns():
+        with ui.card():
+            ui.input_text("text_in", label)
+        with ui.card():
+
+            @render.text
+            def text_out():
+                return f'{module_id} says: "{input.text_in()}"'
+
+
+extra_ids = ["row_3", "row_4", "row_5"]
+
+io_row("row_1")
+io_row("row_2")
+[io_row(x) for x in extra_ids]
+```
+:::
+
+### Core
+
+::: {.column-page}
+```{shinylive-python}
+#| standalone: true
+#| components: [editor, viewer]
+## file: app.py
+from shiny import App, module, render, ui
+from shiny.module import current_namespace
+
+
+@module.ui
+def row_ui():
+    # The module's own id, without having to pass it in a second time
+    module_id = current_namespace()
+    is_special = module_id.endswith(("3", "5"))
+    label = "Enter something special" if is_special else "Enter text"
+    return ui.layout_columns(
+        ui.card(ui.input_text("text_in", label)),
+        ui.card(ui.output_text("text_out")),
+    )
+
+
+@module.server
+def row_server(input, output, session):
+    module_id = current_namespace()
+
+    @render.text
+    def text_out():
+        return f'{module_id} says: "{input.text_in()}"'
+
+
+extra_ids = ["row_3", "row_4", "row_5"]
+
+app_ui = ui.page_fluid(
+    row_ui("row_1"),
+    row_ui("row_2"),
+    [row_ui(x) for x in extra_ids],
+)
+
+
+def server(input, output, session):
+    row_server("row_1")
+    row_server("row_2")
+    [row_server(x) for x in extra_ids]
+
+
+app = App(app_ui, server)
+```
+:::
+
+:::
+
 ## Conclusion
 
 Whenever you find that your Shiny code is repetitive, you should consider whether it's worth extracting some logic into a function or a module.

--- a/docs/modules.qmd
+++ b/docs/modules.qmd
@@ -561,11 +561,12 @@ app = App(app_ui, server)
 The same applies when you write a custom component, since the component's HTML is written by hand.
 For a longer example, see [Custom JavaScript component](custom-component-one-off.qmd).
 
-## Getting the current module id
+## Getting a module's own ID
 
-A module function does not receive its own id as an argument: `@module.ui` and `@module.server` consume the id you pass and turn it into the namespace.
-So if a module's behavior needs to depend on its own id, it's tempting to add a parameter for it and pass the id in twice, as in `row_ui("row_1", "row_1")`.
-You don't have to. Call `current_namespace()` inside the module instead:
+A module function doesn't receive its own ID as an argument. The `@module.ui` and `@module.server` decorators take the
+ID you pass in and turn it into the namespace, so it never reaches your function. If your module's behavior needs to
+depend on its own ID, you might be tempted to add a parameter for it and pass the ID in twice, as in
+`row_ui("row_1", "row_1")`. This isn't necessary, because you can call `current_namespace()` inside the module to get it.
 
 ```{.python}
 from shiny import module
@@ -577,14 +578,15 @@ def row_ui():
     ...
 ```
 
-A few things to know about the value it returns:
+There are a few helpful things to know about the value this returns: it is the fully resolved namespace, which
+means it includes the ID you passed along with the namespaces of any modules that enclose it. A top-level call to
+`row_ui("row_1")` returns `"row_1"`, but if `row_ui("inner")` is called inside a module created with `outer_ui("out")`,
+it returns `"out-inner"`. Also, the value is a subclass of `str`, so you can use normal string methods on it.
+It works in module server functions as well as module UI functions, and outside of a module it returns an empty string,
+because the top level of an application has no namespace.
 
-- It is the *fully resolved* namespace, meaning the id you passed prefixed by the namespaces of any enclosing modules. A top-level `row_ui("row_1")` sees `"row_1"`, but a `row_ui("inner")` called inside a module that was created as `outer_ui("out")` sees `"out-inner"`.
-- It is a `str` subclass, so ordinary string methods work on it.
-- It works in module server functions as well as module UI functions.
-- Outside of any module it returns an empty string, since the top level of an app has no namespace.
-
-In the app below, the label a row uses depends on its own id, and the row's output reports which row it belongs to — neither of which requires threading the id through an extra parameter.
+In the app below, the label each row uses depends on its own ID, and the row's output reports which row it belongs to.
+Neither of these requires passing the ID in through an extra parameter.
 
 ::: {.panel-tabset .panel-pills}
 
@@ -601,7 +603,7 @@ from shiny.module import current_namespace
 
 @module
 def io_row(input, output, session):
-    # The module's own id, without having to pass it in a second time
+    # The module's own ID, without having to pass it in a second time
     module_id = current_namespace()
     is_special = module_id.endswith(("3", "5"))
     label = "Enter something special" if is_special else "Enter text"
@@ -637,7 +639,7 @@ from shiny.module import current_namespace
 
 @module.ui
 def row_ui():
-    # The module's own id, without having to pass it in a second time
+    # The module's own ID, without having to pass it in a second time
     module_id = current_namespace()
     is_special = module_id.endswith(("3", "5"))
     label = "Enter something special" if is_special else "Enter text"


### PR DESCRIPTION
Two documentation requests from posit-dev/py-shiny#2019 and posit-dev/py-shiny#2127 that touch the same page (`docs/modules.qmd`), so they're bundled here as one PR.

## posit-dev/py-shiny#2019 — `resolve_id()` for ids in custom HTML

The reporter expected `@module.ui` to namespace an `id` passed to `ui.div()`. It wasn't obvious that this is not how that decorator works, so it's worth updating the module docs to reflect how this works in reality.

New section **"Namespacing ids in custom HTML"** explains that `@module.ui` does not rewrite the UI it receives. It only sets the current namespace, and it's each `ui.input_*()` / `ui.output_*()` function that looks the namespace up and prefixes its own id. That's why a hand-written `id=` passes through untouched, and why `resolve_id()` works around the issue. Includes the issue's before/after snippets and an Express/Core app where the resolved id genuinely matters (each module instance inserts into its own `ui.insert_ui()` target).

## posit-dev/py-shiny#2127 — Making use of `current_namespace()` more explicit

New section **"Getting the current module id"** documents `current_namespace()`, including that the value is the fully resolved namespace (`"out-inner"` for a module nested inside `outer_ui("out")`), that it's a `str` subclass, that it works in server functions as well as UI functions, and that it's empty outside a module. The Express/Core example is the reporter's case: label and output vary by module id, with no extra parameter.

## Verification

- `shiny.module.resolve_id` and `shiny.module.current_namespace` both confirmed present and in `shiny.module.__all__` on released shiny 1.7.0.
- Every snippet was executed to verify the outputs against current shiny. The two `print(modui("modid"))` examples produce exactly the `<div id="divid">` / `<div id="modid-divid">` output shown.
- All four example apps run under `shiny run`, and the interactive behavior was checked with Playwright: notes insert into the correct per-instance container, and the `row_3`/`row_5` labels and per-row outputs are correct.
- `quarto render docs/modules.qmd` succeeds; both new sections and all shinylive blocks render.

## Note for reviewers

- One cross-link added, from the new `resolve_id()` section to [Custom JavaScript component](https://shiny.posit.co/py/docs/custom-component-one-off.html), which already uses `resolve_id()` for exactly this reason. No other page was touched.
- `current_namespace` is exported in `shiny.module.__all__` (since 2022) but has no docstring and isn't in the API reference (`_quartodoc-core.yml` lists only `module.ui` and `module.server`). Documenting it here as public seems right given the maintainer recommended it on the issue, but adding a docstring + reference entry in py-shiny would be a reasonable follow-up.
- The rendered documentation has little red squiggles for `resolve_id` and `current_namespace` imports, which is this issue that needs a separate fix (it still works, it's just an editor nit): https://github.com/posit-dev/py-shiny/issues/2425

## Screenshots

<img width="1558" height="1940" alt="image" src="https://github.com/user-attachments/assets/d2c8b811-c343-4e40-8c00-a5f68971b907" />

<img width="2868" height="1670" alt="image" src="https://github.com/user-attachments/assets/1c0d7b39-851a-40b8-a320-294ecc1732ca" />

<img width="1438" height="1382" alt="image" src="https://github.com/user-attachments/assets/37f3f07d-e803-440a-b6d6-631d893df15f" />

<img width="2434" height="1316" alt="image" src="https://github.com/user-attachments/assets/d81b8d7b-8bcf-41ca-9e4f-2f176d758b38" />

