### PR TITLE
build: pin the Jupyter kernel to python3 project-wide

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -340,6 +340,10 @@ website:
     # added entry below to prevent this.
     - id: deploy
 
+# Pin the Jupyter kernel project-wide. Without this, Quarto auto-discovers a
+# kernel and can pick one outside `.venv` on machines with several registered.
+jupyter: python3
+
 format:
   html:
     # it appears that these are applied to all rendered pages, and _metadata.yml


### PR DESCRIPTION
Supersedes #14.

## Problem

Quarto auto-discovers a Jupyter kernel for documents with executable cells. On a machine with several registered kernels it can select one outside `.venv`, which is what #14's author hit back in 2023.

Today only `get-started/shinylive.qmd` declares a kernel, while 10 non-submodule `.qmd` files contain executable ` ```{python} ` cells (`index.qmd`, `docs/nonblocking.qmd`, `docs/comp-streamlit.qmd`, `docs/comp-r-shiny.qmd`, the five `layouts/*/index.qmd`, and `get-started/shinylive.qmd`). The rest rely on auto-discovery.

It doesn't bite CI, which is a clean box with one kernel, and the Makefile routes everything through `uv run` so `.venv` is normally what's discovered. This is a defensive fix for contributor machines.

## Why not #14

#14 edits `docs/workflow-modules.qmd`, which no longer exists — the modules docs are now `docs/modules.qmd` and `docs/module-communication.qmd`. It is also `CONFLICTING`, and its diff inserts `jupyter: python3` *above* the opening `---`, so the line would render as literal body text rather than parse as front matter.

One top-level key in `_quarto.yml` covers all 10 files plus any future one.

## Render-time verification

Setting `jupyter:` at project level raised the question of whether it forces the Jupyter engine onto every markdown-only page. Measured on `get-started/` (11 files, 10 of them markdown-only):

| | wall | user CPU | kernel starts |
|---|---|---|---|
| without | 70.0s | 37.7s | 4 |
| with | 77.8s | 37.2s | 4 |

Identical CPU time and identical kernel-start counts — the wall difference is noise. The key only names the kernel when the Jupyter engine is already selected; it does not pull markdown-only pages onto that engine.

## Notes

- `get-started/shinylive.qmd:4` now has a redundant local `jupyter: python3`. Left in place — harmless, and removing it is unrelated churn.
- Per CLAUDE.md, `_quarto.yml` changes warrant a full `make site-parallel` before merge. **I have not run one** — the sharded CI build on this PR is the check to watch.