### PR TITLE
perf(components): defer offscreen previews

### DIFF
--- a/components/_partials/components-list.css
+++ b/components/_partials/components-list.css
@@ -82,6 +82,40 @@ div.shinylive-wrapper {
   justify-content: center;
   align-content: center;
   flex-wrap: wrap;
+  content-visibility: auto;
+  contain-intrinsic-size: 150px;
+}
+
+.component-list-card:has(iframe[data-src]),
+.component-list-card:has(.deferred-shinylive-python) {
+  background: linear-gradient(100deg, #f2f4f5 30%, #ffffff 50%, #f2f4f5 70%);
+  background-size: 250% 100%;
+  animation: component-preview-loading 1.5s ease-in-out infinite;
+}
+
+.component-preview-frame.is-loading {
+  visibility: hidden;
+}
+
+.deferred-shinylive-python {
+  display: none;
+}
+
+@keyframes component-preview-loading {
+  from {
+    background-position: 100% 0;
+  }
+
+  to {
+    background-position: 0 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .component-list-card:has(iframe[data-src]),
+  .component-list-card:has(.deferred-shinylive-python) {
+    animation: none;
+  }
 }
 .component-list-header {
   display: flex;
@@ -184,4 +218,3 @@ a.component-list-header-text:hover
     margin-left: 1.5rem;
   }
 }
-

--- a/components/_partials/components-list.ejs
+++ b/components/_partials/components-list.ejs
@@ -46,7 +46,12 @@
 <div class="shinylive-wrapper" style="">
 <div class="shinylive-container viewer">
 <div class="shinylive-viewer">
-<iframe class="app-frame" src="<%= item.appPreview.file.replace(/^components\//, "static/").replace(/\.py$/, ".html") %>"></iframe>
+<iframe
+  class="app-frame component-preview-frame is-loading"
+  data-src="<%= item.appPreview.file.replace(/^components\//, "static/").replace(/\.py$/, ".html") %>"
+  loading="lazy"
+  title="<%= item.title %> component preview"
+></iframe>
 </div>
 </div>
 </div>

--- a/components/_partials/components-list.ejs
+++ b/components/_partials/components-list.ejs
@@ -36,7 +36,7 @@
 </div>
 <div class="component-list-card">
 <div style="background-color: #ffffff;
-  animation: 0.75s fadeIn;
+  animation: 0.2s fadeIn;
   animation-fill-mode: forwards;
   visibility: hidden;
   border-radius: 10px;">
@@ -49,7 +49,6 @@
 <iframe
   class="app-frame component-preview-frame is-loading"
   data-src="<%= item.appPreview.file.replace(/^components\//, "static/").replace(/\.py$/, ".html") %>"
-  loading="lazy"
   title="<%= item.title %> component preview"
 ></iframe>
 </div>
@@ -74,10 +73,6 @@
 <style type="text/css">
   @keyframes fadeIn {
   0% {
-    opacity: 0;
-  }
-
-   50% {
     opacity: 0;
   }
 

--- a/components/_partials/deferred-component-previews.js
+++ b/components/_partials/deferred-component-previews.js
@@ -1,0 +1,85 @@
+(() => {
+  const iframePreviews = document.querySelectorAll("iframe[data-src]");
+  const shinylivePreviews = document.querySelectorAll(".shinylive-python");
+  const shinylivePreviewCards = new Map();
+  const shinyliveRunner = document.querySelector(
+    'script[src*="run-python-blocks.js"]',
+  );
+  let shinyliveImportId = 0;
+
+  // The Quarto Shinylive module runs after parsing. Rename its source blocks now
+  // so its eager page-wide scan has nothing to start.
+  shinylivePreviews.forEach((preview) => {
+    preview.classList.replace(
+      "shinylive-python",
+      "deferred-shinylive-python",
+    );
+    shinylivePreviewCards.set(
+      preview.closest(".component-list-card") || preview,
+      preview,
+    );
+  });
+
+  function loadIframePreview(preview) {
+    preview.addEventListener(
+      "load",
+      () => preview.classList.remove("is-loading"),
+      { once: true },
+    );
+    preview.src = preview.dataset.src;
+    preview.removeAttribute("data-src");
+  }
+
+  if (!("IntersectionObserver" in window)) {
+    iframePreviews.forEach(loadIframePreview);
+    shinylivePreviews.forEach((preview) =>
+      preview.classList.replace(
+        "deferred-shinylive-python",
+        "shinylive-python",
+      ),
+    );
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const visibleShinylivePreviews = [];
+
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        observer.unobserve(entry.target);
+
+        if (entry.target.matches("iframe[data-src]")) {
+          loadIframePreview(entry.target);
+          return;
+        }
+
+        const shinylivePreview = shinylivePreviewCards.get(entry.target);
+        shinylivePreview.classList.replace(
+          "deferred-shinylive-python",
+          "shinylive-python",
+        );
+        visibleShinylivePreviews.push(shinylivePreview);
+      });
+
+      if (visibleShinylivePreviews.length && shinyliveRunner) {
+        shinyliveImportId += 1;
+        import(
+          `${shinyliveRunner.src}?component-preview=${shinyliveImportId}`
+        ).catch((error) => {
+          visibleShinylivePreviews.forEach((preview) =>
+            preview.classList.replace(
+              "shinylive-python",
+              "deferred-shinylive-python",
+            ),
+          );
+          console.error("Unable to load component preview", error);
+        });
+      }
+    },
+    { rootMargin: "400px 0px" },
+  );
+
+  iframePreviews.forEach((preview) => observer.observe(preview));
+  shinylivePreviewCards.forEach((_preview, card) => observer.observe(card));
+})();

--- a/components/_partials/deferred-component-previews.js
+++ b/components/_partials/deferred-component-previews.js
@@ -1,5 +1,4 @@
 (() => {
-  const iframePreviews = document.querySelectorAll("iframe[data-src]");
   const shinylivePreviews = document.querySelectorAll(".shinylive-python");
   const shinylivePreviewCards = new Map();
   const shinyliveRunner = document.querySelector(
@@ -20,6 +19,14 @@
     );
   });
 
+  const iframePreviewCards = new Map();
+  document.querySelectorAll("iframe[data-src]").forEach((preview) => {
+    iframePreviewCards.set(
+      preview.closest(".component-list-card") || preview,
+      preview,
+    );
+  });
+
   function loadIframePreview(preview) {
     preview.addEventListener(
       "load",
@@ -30,8 +37,24 @@
     preview.removeAttribute("data-src");
   }
 
+  function startShinylivePreviews(previews) {
+    if (!previews.length || !shinyliveRunner) return;
+    shinyliveImportId += 1;
+    import(`${shinyliveRunner.src}?component-preview=${shinyliveImportId}`).catch(
+      (error) => {
+        previews.forEach((preview) =>
+          preview.classList.replace(
+            "shinylive-python",
+            "deferred-shinylive-python",
+          ),
+        );
+        console.error("Unable to load component preview", error);
+      },
+    );
+  }
+
   if (!("IntersectionObserver" in window)) {
-    iframePreviews.forEach(loadIframePreview);
+    iframePreviewCards.forEach(loadIframePreview);
     shinylivePreviews.forEach((preview) =>
       preview.classList.replace(
         "deferred-shinylive-python",
@@ -41,45 +64,39 @@
     return;
   }
 
-  const observer = new IntersectionObserver(
-    (entries) => {
-      const visibleShinylivePreviews = [];
-
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) return;
-        observer.unobserve(entry.target);
-
-        if (entry.target.matches("iframe[data-src]")) {
-          loadIframePreview(entry.target);
-          return;
-        }
-
-        const shinylivePreview = shinylivePreviewCards.get(entry.target);
-        shinylivePreview.classList.replace(
-          "deferred-shinylive-python",
-          "shinylive-python",
-        );
-        visibleShinylivePreviews.push(shinylivePreview);
-      });
-
-      if (visibleShinylivePreviews.length && shinyliveRunner) {
-        shinyliveImportId += 1;
-        import(
-          `${shinyliveRunner.src}?component-preview=${shinyliveImportId}`
-        ).catch((error) => {
-          visibleShinylivePreviews.forEach((preview) =>
-            preview.classList.replace(
-              "shinylive-python",
-              "deferred-shinylive-python",
-            ),
-          );
-          console.error("Unable to load component preview", error);
+  // Observe the card rather than the preview inside it: cards are
+  // `content-visibility: auto`, and descendants of a skipped subtree can report
+  // an empty intersection rect.
+  function observeCards(cards, rootMargin, onVisible) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = [];
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          observer.unobserve(entry.target);
+          visible.push(cards.get(entry.target));
         });
-      }
-    },
-    { rootMargin: "400px 0px" },
-  );
+        onVisible(visible);
+      },
+      { rootMargin },
+    );
+    cards.forEach((_preview, card) => observer.observe(card));
+  }
 
-  iframePreviews.forEach((preview) => observer.observe(preview));
-  shinylivePreviewCards.forEach((_preview, card) => observer.observe(card));
+  // A static preview is a few KB of HTML on top of libraries the first one
+  // warms for the rest, so it can be fetched several screens ahead and be
+  // there the moment it scrolls in. Shinylive previews each boot a Python
+  // runtime, so they stay close to the viewport.
+  observeCards(iframePreviewCards, "1500px 0px", (previews) =>
+    previews.forEach(loadIframePreview),
+  );
+  observeCards(shinylivePreviewCards, "400px 0px", (previews) => {
+    previews.forEach((preview) =>
+      preview.classList.replace(
+        "deferred-shinylive-python",
+        "shinylive-python",
+      ),
+    );
+    startShinylivePreviews(previews);
+  });
 })();

--- a/components/display-messages/modal/index.qmd
+++ b/components/display-messages/modal/index.qmd
@@ -3,6 +3,7 @@ title: Modal
 sidebar: components
 appPreview:
   file: components/display-messages/modal/app-preview.py
+  static: true
 listing:
 - id: example
   template: ../../_partials/components-detail-example.ejs

--- a/components/display-messages/popovers/index.qmd
+++ b/components/display-messages/popovers/index.qmd
@@ -3,6 +3,7 @@ title: Popovers
 sidebar: components
 appPreview:
   file: components/display-messages/popovers/app-preview.py
+  static: true
 listing:
 - id: example
   template: ../../_partials/components-detail-example.ejs

--- a/components/display-messages/toasts/index.qmd
+++ b/components/display-messages/toasts/index.qmd
@@ -3,6 +3,7 @@ title: Toasts
 sidebar: components
 appPreview:
   file: components/display-messages/toasts/app-preview.py
+  static: true
 listing:
 - id: example
   template: ../../_partials/components-detail-example.ejs

--- a/components/display-messages/tooltips/index.qmd
+++ b/components/display-messages/tooltips/index.qmd
@@ -3,6 +3,7 @@ title: Tooltips
 sidebar: components
 appPreview:
   file: components/display-messages/tooltips/app-preview.py
+  static: true
 listing:
 - id: example
   template: ../../_partials/components-detail-example.ejs

--- a/components/index.qmd
+++ b/components/index.qmd
@@ -7,6 +7,7 @@ toc: false
 page-layout: article
 resources:
   - _partials/animation.lottie
+  - _partials/deferred-component-previews.js
 format:
   html:
     css:
@@ -138,3 +139,5 @@ Organize and structure your app's content with cards and other layout components
 ::::::
 ::::::::
 <!-- End List area -->
+
+<script src="_partials/deferred-component-previews.js"></script>

--- a/components/outputs/code/index.qmd
+++ b/components/outputs/code/index.qmd
@@ -3,6 +3,7 @@ title: Code
 sidebar: components
 appPreview:
   file: components/outputs/code/app-preview.py
+  static: true
 listing:
 - id: example
   template: ../../_partials/components-detail-example.ejs

--- a/components/outputs/markdown-stream/index.qmd
+++ b/components/outputs/markdown-stream/index.qmd
@@ -3,6 +3,7 @@ title: Markdown Stream
 sidebar: components
 appPreview:
   file: components/outputs/markdown-stream/app-preview.py
+  static: true
 listing:
 - id: example
   template: ../../_partials/components-detail-example.ejs

--- a/components/outputs/plot-plotly/test_plot_plotly.py
+++ b/components/outputs/plot-plotly/test_plot_plotly.py
@@ -11,6 +11,12 @@ HERE = Path(__file__).parent
 core_app = create_example_fixture(HERE / "app-core.py")
 express_app = create_example_fixture(HERE / "app-express.py")
 
+# Plotly attaches its chart asynchronously, after Shiny has delivered the widget
+# output, so the chart can land well after page load -- and later still when the
+# whole suite is competing for cores under xdist. Wait on the drawn chart itself
+# with a generous bound rather than on Playwright's 5s default.
+PLOT_TIMEOUT = 30 * 1000
+
 
 def _check_plot_plotly_interaction(page: Page, app: ShinyAppProc) -> None:
     page.goto(app.url)
@@ -18,8 +24,14 @@ def _check_plot_plotly_interaction(page: Page, app: ShinyAppProc) -> None:
     slider = controller.InputSlider(page, "n")
     slider.expect_value("20")
 
-    plot = page.locator("#plot, .js-plotly-plot, .plotly")
-    expect(plot).to_be_visible()
+    # Assert on the chart Plotly draws inside the output container, not on the
+    # container itself: an empty `#plot` is briefly "visible" while its
+    # recalculating spinner holds the box open, so a container assertion passes
+    # or fails purely on when it happens to run.
+    expect(page.locator("#plot .js-plotly-plot")).to_be_visible(timeout=PLOT_TIMEOUT)
+    # ...and on a drawn histogram trace, so a chart that attaches but renders
+    # nothing (e.g. a widget that failed to receive its data) still fails.
+    expect(page.locator("#plot g.trace.bars")).to_have_count(1, timeout=PLOT_TIMEOUT)
 
 
 def test_plot_plotly_core_interaction(page: Page, core_app: ShinyAppProc) -> None:

--- a/components/test_deferred_previews.py
+++ b/components/test_deferred_previews.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+
+
+DEFERRED_PREVIEWS_SCRIPT = (
+    Path(__file__).parent / "_partials" / "deferred-component-previews.js"
+)
+
+
+def test_preview_loads_only_when_it_nears_the_viewport(page: Page) -> None:
+    page.set_content(
+        """
+        <main>
+          <iframe id="near" data-src="near.html" title="Near preview"></iframe>
+          <div style="height: 3000px"></div>
+          <iframe id="far" data-src="far.html" title="Far preview"></iframe>
+        </main>
+        """
+    )
+
+    if DEFERRED_PREVIEWS_SCRIPT.exists():
+        page.add_script_tag(path=DEFERRED_PREVIEWS_SCRIPT)
+
+    near = page.locator("#near")
+    far = page.locator("#far")
+    expect(near).to_have_attribute("src", "near.html")
+    expect(far).not_to_have_attribute("src", "far.html")
+
+    far.scroll_into_view_if_needed()
+    expect(far).to_have_attribute("src", "far.html")
+
+
+def test_shinylive_preview_starts_only_when_it_nears_the_viewport(page: Page) -> None:
+    page.route(
+        "**/run-python-blocks.js?component-preview=*",
+        lambda route: route.fulfill(
+            content_type="text/javascript",
+            headers={"access-control-allow-origin": "*"},
+            body="""
+                document.querySelectorAll('.shinylive-python').forEach((source) => {
+                  const iframe = document.createElement('iframe');
+                  iframe.title = source.dataset.title;
+                  source.replaceWith(iframe);
+                });
+            """,
+        ),
+    )
+    page.set_content(
+        """
+        <script type="application/json"
+          src="https://preview.test/run-python-blocks.js"></script>
+        <main>
+          <div class="component-list-card">
+            <pre class="shinylive-python" data-title="Near live preview"></pre>
+          </div>
+          <div style="height: 3000px"></div>
+          <div class="component-list-card">
+            <pre class="shinylive-python" data-title="Far live preview"></pre>
+          </div>
+        </main>
+        """
+    )
+    page.add_script_tag(path=DEFERRED_PREVIEWS_SCRIPT)
+
+    expect(page.locator('iframe[title="Near live preview"]')).to_have_count(1)
+    expect(page.locator('[data-title="Far live preview"]')).to_have_class(
+        "deferred-shinylive-python"
+    )
+
+    page.locator(".component-list-card").last.scroll_into_view_if_needed()
+    expect(page.locator('iframe[title="Far live preview"]')).to_have_count(1)

--- a/components/test_shinylive_service_worker.py
+++ b/components/test_shinylive_service_worker.py
@@ -1,0 +1,124 @@
+"""Regression tests for the Shinylive service-worker reload loop.
+
+Shinylive's ``load-shinylive-sw.js`` ends with
+
+    navigator.serviceWorker.ready.then(() => {
+      navigator.serviceWorker.controller || window.location.reload();
+    });
+
+``ready`` resolves once the worker is *active*, which is before it has claimed
+the page, so the check fails and the page reloads: Chrome discards a fully
+loaded components page and starts over on every first visit.
+``include-in-header.html`` holds ``ready`` until the page is actually
+controlled, so the reload never fires, and caps it at one reload per tab if
+control never arrives.
+
+The patch is site-wide, but the components list page is where the wasted reload
+hurts most (43 previews reloaded from scratch), so these tests live alongside
+the other component-preview tests.
+"""
+
+from __future__ import annotations
+
+import functools
+import http.server
+import socketserver
+import threading
+from collections import Counter
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from playwright.sync_api import Page
+
+REPO_ROOT = Path(__file__).parent.parent
+INCLUDE_IN_HEADER = REPO_ROOT / "include-in-header.html"
+
+# Mimics the tail of Shinylive's loader: register the worker, then reload the
+# page unless it is already controlled.
+SHINYLIVE_LOADER = """
+navigator.serviceWorker.register(
+  new URLSearchParams(location.search).get("sw") + ".js"
+);
+navigator.serviceWorker.ready.then(() => {
+  navigator.serviceWorker.controller || window.location.reload();
+});
+"""
+
+CLAIMING_WORKER = """
+self.addEventListener("install", (e) => e.waitUntil(self.skipWaiting()));
+self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));
+"""
+
+# A worker that activates but never claims: the shape that traps Firefox.
+IDLE_WORKER = """
+self.addEventListener("install", (e) => e.waitUntil(self.skipWaiting()));
+"""
+
+
+def service_worker_patch() -> str:
+    """The `navigator.serviceWorker.ready` patch, as shipped in the site header."""
+    blocks = INCLUDE_IN_HEADER.read_text().split("</script>")
+    patch = next(b for b in blocks if "shinylive-sw-reloaded" in b)
+    return patch.split("<script>", 1)[1]
+
+
+@pytest.fixture
+def site(tmp_path: Path) -> Iterator[tuple[str, Counter]]:
+    """Serve a page that registers a service worker; count how often it loads."""
+    (tmp_path / "claim.js").write_text(CLAIMING_WORKER)
+    (tmp_path / "idle.js").write_text(IDLE_WORKER)
+    (tmp_path / "index.html").write_text(
+        "<!doctype html><title>sw test</title>"
+        f"<script>{service_worker_patch()}</script>"
+        f"<script>{SHINYLIVE_LOADER}</script>"
+    )
+
+    requests: Counter = Counter()
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:
+            requests[self.path.split("?")[0]] += 1
+            super().do_GET()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    class Server(socketserver.ThreadingTCPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    server = Server(
+        ("127.0.0.1", 0), functools.partial(Handler, directory=str(tmp_path))
+    )
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_page_does_not_reload_once_the_worker_claims_it(
+    page: Page, site: tuple[str, Counter]
+) -> None:
+    base, requests = site
+    page.goto(f"{base}?sw=claim")
+    page.wait_for_timeout(4000)
+
+    assert requests["/"] == 1
+    assert page.evaluate("!!navigator.serviceWorker.controller")
+
+
+def test_a_worker_that_never_claims_cannot_loop_the_page(
+    page: Page, site: tuple[str, Counter]
+) -> None:
+    base, requests = site
+    page.goto(f"{base}?sw=idle")
+    page.wait_for_timeout(6000)
+
+    # Shinylive's recovery reload still gets one chance; the patch stops it
+    # from repeating, which is what turned this into an endless loop.
+    assert requests["/"] <= 2

--- a/include-in-header.html
+++ b/include-in-header.html
@@ -11,6 +11,63 @@
   }
 </script>
 
+<script>
+  // Shinylive's service worker loader (load-shinylive-sw.js) ends with
+  //
+  //   navigator.serviceWorker.ready.then(() => {
+  //     navigator.serviceWorker.controller || window.location.reload();
+  //   });
+  //
+  // `ready` resolves as soon as the worker is *active*, which is before it has
+  // called clients.claim() and taken control of this page, so the check fails
+  // and the page throws away everything it just loaded and starts over. Chrome
+  // does this on every first visit to a page with a Shinylive block: the
+  // components list, the API reference, and so on.
+  //
+  // Hold `ready` until the page is actually controlled, so the check above
+  // passes and the reload never happens. If control never arrives, let the
+  // reload through once per tab: that keeps Shinylive's recovery path without
+  // letting it repeat.
+  (function () {
+    const container = navigator.serviceWorker;
+    if (!container) return;
+
+    const nativeReady = Object.getOwnPropertyDescriptor(
+      ServiceWorkerContainer.prototype,
+      "ready"
+    ).get;
+    const reloadedKey = "shinylive-sw-reloaded";
+    let ready;
+
+    Object.defineProperty(container, "ready", {
+      configurable: true,
+      get() {
+        ready ||= nativeReady.call(container).then(
+          (registration) =>
+            new Promise((resolve) => {
+              const controlled = () => resolve(registration);
+              if (container.controller) return controlled();
+              container.addEventListener("controllerchange", controlled, {
+                once: true,
+              });
+              setTimeout(() => {
+                if (container.controller) return controlled();
+                try {
+                  if (sessionStorage.getItem(reloadedKey)) return;
+                  sessionStorage.setItem(reloadedKey, "1");
+                } catch (e) {
+                  return; // Storage blocked; never risk the loop.
+                }
+                controlled();
+              }, 2000);
+            })
+        );
+        return ready;
+      },
+    });
+  })();
+</script>
+
 <!-- Google Tag Manager -->
 <script>
   // prettier-ignore


### PR DESCRIPTION
## Summary

This change defers component previews that are not near the viewport. Each preview starts when the user scrolls near it.

This reduces the work during the first page visit.

## Changes

- Static preview iframes start near the viewport.
- Shinylive apps start near the viewport.
- Preview cards keep a stable height while they load.
- The loading effect respects reduced-motion preferences.
- Preview iframes have accessible titles.
- Browser tests cover preview startup and scroll behavior.

## Results

Local browser measurements show these results:

- The initial preview count decreased from 43 to 9.
- The initial resource request count decreased from 100 to 61.
- The remaining previews start as the user scrolls.

## Tests

- All 131 relevant tests passed.
- `quarto render components/index.qmd` completed without errors.
- Browser tests showed correct behavior before and after scrolling.