### PR TITLE
docs(testing): Document --test-file and the shiny add test model aliases

### DIFF
--- a/docs/end-to-end-testing.qmd
+++ b/docs/end-to-end-testing.qmd
@@ -193,10 +193,24 @@ Before generating tests, make sure you have:
 pip install "shiny[add-test]"
 ```
 
+#### Specifying the app and test file
+
+To skip the prompts, pass the paths on the command line:
+
+```bash
+# Writes test_app_dashboard.py next to the app
+shiny add test --app app_dashboard.py
+
+# Choose both paths yourself
+shiny add test --app app_dashboard.py --test-file test_dashboard.py
+```
+
+When `--test-file` is omitted, the test file is named `test_` plus the app file name and written alongside the app. Whichever way you name it, the file must start with `test_` and must not already exist — `shiny add test` will not overwrite a test you have already written.
+
 #### Choosing a provider for generating tests
 
 ```bash
-# Anthropic (default)
+# Anthropic (default; uses the sonnet model)
 shiny add test --app app.py
 
 # OpenAI (will use gpt-5)
@@ -204,6 +218,25 @@ shiny add test --app app.py --provider openai
 
 # explicitly use gpt-5-mini model
 shiny add test --app app.py --provider openai --model gpt-5-mini
+```
+
+`--model` takes one of these aliases rather than a full model name:
+
+| Provider | Alias | Model |
+|----------|-------|-------|
+| `anthropic` | `sonnet` (default) | `claude-sonnet-4-20250514` |
+| `anthropic` | `haiku3.5` | `claude-3-5-haiku-20241022` |
+| `openai` | `gpt-5` (default) | `gpt-5-2025-08-07` |
+| `openai` | `gpt-5-mini` | `gpt-5-mini-2025-08-07` |
+
+Generation runs against your own API key, so each invocation consumes tokens and costs money. The command reports both when it finishes:
+
+```
+🤖 Generating test using anthropic provider...
+LLM token usage and cost:
+Anthropic (claude-sonnet-4-20250514): 12.3k input, 2.1k output | Cost $0.0845 | Time taken: 8.45s
+
+✅ Test file generated successfully: test_app.py
 ```
 
 ### Troubleshooting Common Issues


### PR DESCRIPTION
Fills three gaps in the "Adding Tests to an Existing Shiny App" section of `docs/end-to-end-testing.qmd`. Salvaged from #321 (closed unmerged), keeping only the parts that aren't already documented — no new page, since the agent-skills route is the preferred story now.

**1. `--test-file` was undocumented.** The section only ever showed `--app`. Adds the flag, the auto-generated default name (`test_<app file name>.py`, written next to the app), and the no-clobber rule — `shiny add test` errors rather than overwriting an existing test file.

**2. `--model` looked like it took arbitrary model names.** It takes one of four aliases (`shiny/pytest/_generate/_main.py:26-34`). Adds the table plus the per-provider defaults, and notes the Anthropic default (`sonnet`) inline in the existing example block.

**3. No mention that this spends money.** Generation runs against the user's own API key. Adds the command's actual completion output, which reports tokens, cost, and elapsed time.

All claims verified against the pinned py-shiny submodule (`shiny/_main/_generate_test.py`, `shiny/pytest/_generate/_main.py`).

Rendered locally with Quarto 1.9.36 — table and code blocks come out clean.