### PR TITLE
docs: fix outdated `shiny create .` command and broken template links

### DIFF
--- a/docs/comp-r-shiny.qmd
+++ b/docs/comp-r-shiny.qmd
@@ -30,12 +30,22 @@ To get started you can do the following (or see the [installation instructions](
 2.  Install Shiny. We strongly recommend using a virtual environment for this as it will eliminate dependency resolution headaches and make deployment easier.
 
 ::: {.panel-tabset .panel-pills}
+### Install with uv
+
+``` bash
+# Create a virtual environment in the .venv subdirectory
+uv venv
+source .venv/bin/activate
+# Install shiny
+uv pip install shiny
+```
+
 ### Install with pip
 
 ``` bash
 # Create a virtual environment in the .venv subdirectory
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 # Install shiny
 pip install shiny
 ```

--- a/docs/comp-r-shiny.qmd
+++ b/docs/comp-r-shiny.qmd
@@ -50,7 +50,7 @@ conda install -c conda-forge shiny
 ```
 :::
 
-3.  Call `shiny create .` to create an example shiny app in your directory
+3.  Call `shiny create --dir .` to create an example shiny app in your directory. You'll be prompted to pick a template; see [create and run](/get-started/create-run.qmd) for more details.
 4.  Call `shiny run --reload` to run the app and reload when the source code changes
 
 ::: callout-tip

--- a/get-started/create-run.qmd
+++ b/get-started/create-run.qmd
@@ -19,7 +19,7 @@ shiny create
 
 You can also get started faster by using one of our [starter templates](/templates/).
 There are templates for common use cases.
-For example, [data dashboards](templates/dashboard/), [applications](/templates/database-explorer/), [streaming](/templates/monitor-database/) updates, or [data entry](/templates/survey/).
+For example, [data dashboards](/templates/dashboard/), [applications](/templates/database-explorer/), [streaming](/templates/monitor-database/) updates, or [data entry](/templates/survey/).
 
 
 ## Run your Shiny application

--- a/get-started/install.qmd
+++ b/get-started/install.qmd
@@ -5,7 +5,7 @@ aliases:
   - /docs/install-create-run.html
 ---
 
-Shiny for Python can be installed via `pip`, `conda`, or `uv`.
+Shiny for Python can be installed via `uv`, `pip`, or `conda`.
 
 ::: {.panel-tabset .panel-pills}
 

--- a/get-started/install.qmd
+++ b/get-started/install.qmd
@@ -9,6 +9,47 @@ Shiny for Python can be installed via `uv`, `pip`, or `conda`.
 
 ::: {.panel-tabset .panel-pills}
 
+#### uv
+
+You can install `shiny` using `uv pip`
+
+```bash
+uv pip install shiny
+```
+
+If you already have `shiny` installed, and you want to upgrade the `shiny` packages,
+you will need to use the `--upgrade` flag.
+
+```bash
+uv pip install --upgrade shiny htmltools
+```
+
+::: {.callout-note collapse="true"}
+##### Virtual environments
+
+{{< include include/why-virtual-env.qmd >}}
+
+You can also use `uv` to create virtual environments with `uv venv` to create a Python `.venv` directory.
+
+```bash
+# Create and move into your shiny application directory
+mkdir myapp
+cd myapp
+
+# Create a virtual environment, defaults to .venv
+uv venv
+
+# Activate the virtual environment
+source .venv/bin/activate
+# .venv\Scripts\Activate.ps1 # on Windows (PowerShell)
+
+# Your prompt will prepend with the current directory name
+
+# Install into venv
+uv pip install shiny
+```
+:::
+
 #### pip
 
 Before installing you may want to upgrade `pip` and install `wheel`.
@@ -106,47 +147,6 @@ conda create --name shiny -c conda-forge shiny python
 conda activate shiny
 
 # Your prompt will be pre-pended with shiny
-```
-:::
-
-#### uv
-
-You can install `shiny` using `uv pip`
-
-```bash
-uv pip install shiny
-```
-
-If you already have `shiny` installed, and you want to upgrade the `shiny` packages,
-you will need to use the `--upgrade` flag.
-
-```bash
-uv pip install --upgrade shiny htmltools
-```
-
-::: {.callout-note collapse="true"}
-##### Virtual environments
-
-{{< include include/why-virtual-env.qmd >}}
-
-You can also use `uv` to create virtual environments with `uv venv` to create a Python `.venv` directory.
-
-```bash
-# Create and move into your shiny application directory
-mkdir myapp
-cd myapp
-
-# Create a virtual environment, defaults to .venv
-uv venv
-
-# Activate the virtual environment
-source .venv/bin/activate
-# .venv\Scripts\Activate.ps1 # on Windows (PowerShell)
-
-# Your prompt will prepend with the current directory name
-
-# Install into venv
-uv pip install shiny
 ```
 :::
 

--- a/get-started/install.qmd
+++ b/get-started/install.qmd
@@ -5,7 +5,7 @@ aliases:
   - /docs/install-create-run.html
 ---
 
-Shiny for Python can be installed can be installed via `pip` or `conda`.
+Shiny for Python can be installed via `pip`, `conda`, or `uv`.
 
 ::: {.panel-tabset .panel-pills}
 

--- a/get-started/what-is-shiny.qmd
+++ b/get-started/what-is-shiny.qmd
@@ -138,7 +138,7 @@ Here's a full Shiny application in action, complete with [reactivity](/docs/reac
 Hit the ground running with one of our [starter templates](/templates/), like the app above, by using `shiny create`.
 
 There are templates for common use cases.
-For example, [data dashboards](templates/dashboard/), [data applications](/templates/database-explorer/), [streaming updates](/templates/monitor-database/), or [data entry](/templates/survey/).
+For example, [data dashboards](/templates/dashboard/), [data applications](/templates/database-explorer/), [streaming updates](/templates/monitor-database/), or [data entry](/templates/survey/).
 
 Use the terminal command below to [create and run](create-run.qmd) the same dashboard locally with `shiny create`, starting from a [template](/templates/).
 


### PR DESCRIPTION
## Problem

Issue #59 reports that the docs tell users to run `shiny create .`, which fails with:

```
Error: Got unexpected extra argument (.)
```

`shiny create` takes no positional arguments — the destination is passed with `-d/--dir`.

The page the issue links to (`docs/install.html`) has since been rewritten and no longer mentions it, but one stale occurrence remained in the Shiny for R comparison page.

## Change

`docs/comp-r-shiny.qmd`: `shiny create .` → `shiny create --dir .`, plus a pointer to the create-and-run page since `shiny create` prompts for a template.

Verified against the pinned py-shiny submodule:

```
$ shiny create --template basic-app --mode core --dir /tmp/shiny59
✓ Created Shiny app at /tmp/shiny59
```

Also grepped the whole site for any other positional-argument `shiny create` usages — none remain.

Closes #59