### PR TITLE
ci: add an internal link checker and fix the links it found

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,20 @@ The custom renderer automatically extracts examples from `py-shiny/shiny/example
 
 ## Site Quality Checks
 
+**`make check-page-links`** — scans the rendered site in `_build/` for broken internal links (`scripts/check-page-links.py`). Requires a current full build; run `make site-parallel` first. Reports three kinds:
+
+- `missing-target` — the link resolves to no file or directory index
+- `missing-anchor` — the page exists but has no element with that `id`/`name` (**opt-in**, `--anchors`)
+- `unrewritten-qmd` — a `.qmd` href survived rendering, so the reader is served source
+
+This exists because Quarto only validates `.qmd` links. A link with no extension (e.g. `templates/dashboard/` instead of `/templates/dashboard/`) is passed through verbatim and silently 404s — see #59's follow-up. Known-broken links are suppressed via `scripts/page-links-allow.txt` (`<kind><TAB><target>`); prefer fixing the link over adding an entry.
+
+**Anchor checking is off by default and not gateable yet.** quartodoc emits interlinks like `api/core/App.html#shiny.App` but never writes a matching `id` attribute on the target page, so `--anchors` reports ~1,500 findings, ~1,460 of them from generated `api/**` output. The ~33 findings originating outside `api/**` are mostly real stale heading anchors — tracked in #448.
+
+**Run it after `make site-parallel`, not `make serve`.** A partial or seeded `_build/` produces large numbers of false positives: `site_libs/` asset hashes drift (excluded for this reason), and unmerged shard output leaves `.qmd` hrefs that `scripts/ci-merge.py` would have rewritten (it resolved 4,851 of them in one measured run).
+
+Unit tests for the checker live in `scripts/test_check_page_links.py` and are **not** collected by `make test-apps` (pytest.ini scopes `testpaths` to `components/`). Run them with `make test-check-page-links`.
+
 **`make compare-versions`** — viewport comparison between production and a local build using Playwright + Claude vision via AWS Bedrock. Run it before merging any change that could affect rendered output site-wide: Quarto version upgrades, Shinylive version upgrades, `_quarto.yml` structural changes, `_renderer.py` changes, or other dependency upgrades. Writes a timestamped markdown report to `tests/`; start with the executive summary.
 
 ### How to run

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,16 @@ SHARDS ?= 6
 site-parallel: $(PYBIN) install-quarto
 	QUARTO_PATH="$(QUARTO_PATH)" SHARDS="$(SHARDS)" scripts/local-parallel-render.sh
 
+## Check the rendered site in _build for broken internal links (run `make site-parallel` first)
+.PHONY: check-page-links
+check-page-links: $(PYBIN)
+	$(UVRUN) python scripts/check-page-links.py --dir _build --allow scripts/page-links-allow.txt
+
+## Unit-test the link checker itself (not collected by test-apps; testpaths=components)
+.PHONY: test-check-page-links
+test-check-page-links: $(PYBIN)
+	$(UVRUN) pytest scripts/test_check_page_links.py -n0
+
 ## Serve existing _build without full re-render (fast preview; run `make site` or `make site-parallel` first)
 .PHONY: serve-fast
 serve-fast: $(PYBIN) install-quarto

--- a/components/outputs/image/index.qmd
+++ b/components/outputs/image/index.qmd
@@ -46,7 +46,7 @@ listing:
 
 To make a reactive image, follow three steps:
 
-  1. Call [`ui.output_image()`](TODO ADD LINK) in the `app_ui` section of your app to create a div in which to display the image.
+  1. Call [`ui.output_image()`](/api/core/ui.output_image.qmd) in the `app_ui` section of your app to create a div in which to display the image.
 
       1. Set the id argument of `ui.output_image()` to a unique value.
       2. Optionally, set `ui.output_image(inline=True)` to place the image inline with the text or elements that precede it.
@@ -64,4 +64,4 @@ To make a reactive image, follow three steps:
 
   3. Decorate the function with `@render.image`. Use `@render.image(delete_file=True)` to delete the image from the server after it has been rendered.
 
-You can use an image as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, follow the instructions provided for [plots as inputs](plot-matplotlib.html#plots-as-inputs).
+You can use an image as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, follow the instructions provided for [plots as inputs](../plot-matplotlib/index.qmd#plots-as-inputs).

--- a/components/outputs/plot-seaborn/index.qmd
+++ b/components/outputs/plot-seaborn/index.qmd
@@ -69,4 +69,4 @@ Follow these steps to display a Seaborn figure in your app:
       - If your plotting function is not the same as the `id` you used in the `ui.output_plot()`, you can add an additional `@output(id=...)` decorator.
       - If you use the `@output()` decorator, make sure it is __above__ the `@render.plot` decorator.
 
-You can use a plot as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, follow the instructions provided for [plots as inputs](plot-matplotlib.html#plots-as-inputs).
+You can use a plot as an input widget, collecting the locations of user clicks, double clicks, hovers, and brushes. To do this, follow the instructions provided for [plots as inputs](../plot-matplotlib/index.qmd#plots-as-inputs).

--- a/docs/express-in-depth.qmd
+++ b/docs/express-in-depth.qmd
@@ -397,8 +397,8 @@ This can be potentially dangerous since one users activity could impact another'
 
 ### Sessions
 
-Shiny apps have an object that represent a particular user's [session](../api/Session.html).
-This object is useful for a variety of more advanced tasks like [sending messages to the client](../api/Session.html#shiny.Session.send_custom_message) and [serving up session-specific data](../api/Session.html#shiny.Session.dynamic_route).
+Shiny apps have an object that represent a particular user's [session](../api/core/Session.qmd).
+This object is useful for a variety of more advanced tasks like [sending messages to the client](../api/core/Session.qmd#shiny.Session.send_custom_message) and [serving up session-specific data](../api/core/Session.qmd#shiny.Session.dynamic_route).
 In Express, you'll need to import `session` from `shiny.express` and only use it inside a reactive function, like a `@reactive.effect`:
 
 ```{shinylive-python}

--- a/docs/genai-chatbots.qmd
+++ b/docs/genai-chatbots.qmd
@@ -524,7 +524,7 @@ app = App(app_ui, server)
 ### Custom icons
 
 Customize the assistant icon by supplying HTML/SVG to `icon_assistant` when creating the UI element (or when appending a message).
-The `faicons` package makes it easy to do this for [font awesome](https://fontawesome.com/), but other icon libraries (e.g., [Bootstrap icons]((https://icons.getbootstrap.com/#usage)), [heroicons](https://heroicons.com/), etc.) or custom SVGs are also possible by providing inline SVGs as a string to `ui.HTML()`.
+The `faicons` package makes it easy to do this for [font awesome](https://fontawesome.com/), but other icon libraries (e.g., [Bootstrap icons](https://icons.getbootstrap.com/#usage), [heroicons](https://heroicons.com/), etc.) or custom SVGs are also possible by providing inline SVGs as a string to `ui.HTML()`.
 
 ::: {.panel-tabset .panel-pills}
 

--- a/docs/jupyter-widgets.qmd
+++ b/docs/jupyter-widgets.qmd
@@ -19,7 +19,7 @@ In this article, we'll learn how to leverage ipywidgets in Shiny, including how 
 ::: callout-note
 ### Not all Jupyter Widgets are ipywidgets
 
-Although the term "Jupyter Widgets" is often used to refer to ipywidgets, it's important to note that not all Jupyter Widgets are ipywidgets. For example, packages like [folium](https://python-visualization.github.io/folium/latest/) and [ipyvizzu](https://ipyvizzu.vizzuhq.com/latest/) aren't compatible with ipywidgets, but do provide a [`_repr_html_` method](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display) for getting the HTML representation. It may be possible to display these widgets using Shiny's [`@render.ui`](../api/render.ui.html) decorator.
+Although the term "Jupyter Widgets" is often used to refer to ipywidgets, it's important to note that not all Jupyter Widgets are ipywidgets. For example, packages like [folium](https://python-visualization.github.io/folium/latest/) and [ipyvizzu](https://ipyvizzu.vizzuhq.com/latest/) aren't compatible with ipywidgets, but do provide a [`_repr_html_` method](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display) for getting the HTML representation. It may be possible to display these widgets using Shiny's [`@render.ui`](../api/core/render.ui.qmd) decorator.
 :::
 
 
@@ -558,7 +558,7 @@ If the extension is properly configured, and still isn't working, here are some 
 1. The widget requires initialization code to work in a notebook environment.
   * In this case, `shinywidgets` probably won't work without providing the equivalent setup information to Shiny. A known case of this is bokeh, shinywidgets' `@render_bokeh` decorator handles through inclusion of additional HTML [dependencies](https://github.com/posit-dev/py-shinywidgets/blob/9ea804c3/shinywidgets/_render_widget.py#L38-L42).
 2. Not all widgets are compatible with ipywidgets!
-  * Some web-based widgets in Python aren't compatible with the ipywidgets framework, but do provide a `repr_html` method for getting the HTML representation (e.g., [folium](https://python-visualization.github.io/folium/latest/)). It may be possible to display these widgets using Shiny's [`@render.ui`](../api/render.ui.html) decorator, but be aware that, you may not be able to do things mentioned in this article with these widgets.
+  * Some web-based widgets in Python aren't compatible with the ipywidgets framework, but do provide a `repr_html` method for getting the HTML representation (e.g., [folium](https://python-visualization.github.io/folium/latest/)). It may be possible to display these widgets using Shiny's [`@render.ui`](../api/core/render.ui.qmd) decorator, but be aware that, you may not be able to do things mentioned in this article with these widgets.
 3. The widget itself is broken.
   * If you think this is the case, try running the code in a notebook to see if it works there. If it doesn't work in a notebook, then it's likely a problem with the widget itself (and the issue should be reported to the widget's maintainers).
 4. The widget is otherwise misconfigured (or your offline).

--- a/docs/nonblocking.qmd
+++ b/docs/nonblocking.qmd
@@ -79,7 +79,7 @@ This is true even if the two reactive effects belong to two different Shiny sess
 This may seem like a strange decision on the part of Shiny: why support async at all if the code is not going to run concurrently?
 
 The reason for supporting async is simple: there are functions you may need to call from reactive contexts that are only available as async functions.
-This includes some functions in Shiny itself that are used to communicate with the browser, like [`Session.send_custom_message`](api/Session.html#shiny.Session.send_custom_message).
+This includes some functions in Shiny itself that are used to communicate with the browser, like [`Session.send_custom_message`](../api/core/Session.qmd#shiny.Session.send_custom_message).
 
 The reason for not allowing (reactive) async code to run concurrently is more nuanced.
 The main reason is that it would be very difficult to ensure that the application behaves predictably if async code were allowed to run concurrently.

--- a/docs/opentelemetry/_resources.qmd
+++ b/docs/opentelemetry/_resources.qmd
@@ -5,9 +5,9 @@ OpenTelemetry integration in Shiny provides powerful observability for productio
 - [OpenTelemetry Python documentation](https://opentelemetry.io/docs/languages/python/)
 - [OpenTelemetry documentation](https://opentelemetry.io/docs/)
 - [Logfire documentation](https://logfire.pydantic.dev/)
-- [Shiny for Python API reference](/api/)
+- [Shiny for Python API reference](/api/core/index.qmd)
 
 For related topics on improving Shiny apps:
 
-- [Testing Shiny applications](../testing/)
-- [Performance](../performance/)
+- [End-to-end testing your app](/docs/end-to-end-testing.qmd)
+- [Non-blocking operations](/docs/nonblocking.qmd)

--- a/scripts/check-page-links.py
+++ b/scripts/check-page-links.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Check a rendered site for broken internal links.
+
+Scans every ``*.html`` under the render directory (default ``_build``) and
+reports ``href``/``src`` targets that do not resolve on disk, plus any ``.qmd``
+href that survived rendering.
+
+Quarto validates ``.qmd`` links, but only those: a link with no extension (e.g.
+``templates/dashboard/``) is passed through verbatim, so a missing leading slash
+silently 404s. This catches that class, along with stale hand-written ``.html``
+paths and unresolved fragments.
+
+Usage::
+
+    scripts/check-page-links.py [--dir _build] [--allow FILE] [--anchors]
+
+Exits 1 if anything is reported.
+
+``--anchors`` is opt-in. quartodoc emits interlinks like
+``api/core/App.html#shiny.App`` but no matching ``id`` attribute on the target
+page, so enabling it reports ~1500 findings from generated ``api/**`` output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from urllib.parse import unquote, urlsplit
+
+# Attribute values we resolve. Deliberately not `srcset` (comma/width syntax).
+ATTR_RE = re.compile(r'(?:href|src)="([^"]*)"')
+
+# Regions whose contents are illustrative or client-side, not site links:
+# code samples name things like `my-styles.css`, and JS/EJS templates carry
+# placeholders (`${href}`, `<%= app.shinylive %>`) that are not URLs at all.
+INERT_RE = re.compile(r"<pre\b.*?</pre>|<code\b.*?</code>|<script\b.*?</script>", re.S)
+
+# Anything not resolved against the filesystem.
+EXTERNAL_RE = re.compile(r"^(?:[a-z][a-z0-9+.-]*:|//)", re.I)
+TEMPLATE_RE = re.compile(r"[<$]%?[={]|\{\{")
+
+# Content-hashed asset paths differ between shard outputs; the merge step owns
+# reconciling them, and a stale local render trips over them constantly.
+SKIP_PATH_RE = re.compile(r"(^|/)site_libs/")
+
+ANCHOR_ID_RE = re.compile(r'\bid="([^"]+)"')
+ANCHOR_NAME_RE = re.compile(r'\bname="([^"]+)"')
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    target: str
+    source: str
+
+    def __str__(self) -> str:
+        return f"{self.kind:<14} {self.target}\n{'':<14} in {self.source}"
+
+
+def load_allowlist(path: str | None) -> set[str]:
+    """Read newline-separated ``kind<TAB>target`` entries.
+
+    Only a leading ``#`` starts a comment -- entries routinely end in a URL
+    fragment (``page.html#anchor``), so mid-line ``#`` is data, not a comment.
+    """
+    if not path:
+        return set()
+    allowed = set()
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                allowed.add(line)
+    return allowed
+
+
+def anchors_of(path: str, cache: dict[str, set[str]]) -> set[str]:
+    if path not in cache:
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                html = fh.read()
+        except OSError:
+            cache[path] = set()
+        else:
+            cache[path] = set(ANCHOR_ID_RE.findall(html)) | set(
+                ANCHOR_NAME_RE.findall(html)
+            )
+    return cache[path]
+
+
+def resolve(root: str, page_dir: str, path: str) -> str | None:
+    """Map a link path to the file that would serve it, or None if nothing does."""
+    if path.startswith("/"):
+        base = os.path.join(root, path.lstrip("/"))
+    else:
+        base = os.path.join(page_dir, path)
+    base = os.path.normpath(base)
+    if os.path.isdir(base):
+        index = os.path.join(base, "index.html")
+        return index if os.path.isfile(index) else None
+    return base if os.path.isfile(base) else None
+
+
+def check(root: str, check_anchors: bool) -> tuple[list[Finding], int]:
+    findings: list[Finding] = []
+    anchor_cache: dict[str, set[str]] = {}
+    pages = 0
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in {"site_libs", ".venv"}]
+        for filename in sorted(filenames):
+            if not filename.endswith(".html"):
+                continue
+            pages += 1
+            page = os.path.join(dirpath, filename)
+            rel_page = os.path.relpath(page, root)
+            with open(page, encoding="utf-8", errors="replace") as fh:
+                html = INERT_RE.sub("", fh.read())
+
+            for raw in dict.fromkeys(ATTR_RE.findall(html)):
+                value = raw.strip()
+                if (
+                    not value
+                    or value.startswith("#")
+                    or EXTERNAL_RE.match(value)
+                    or TEMPLATE_RE.search(value)
+                    or SKIP_PATH_RE.search(value)
+                ):
+                    continue
+
+                split = urlsplit(value)
+                path = unquote(split.path)
+                if not path:
+                    continue
+
+                # A .qmd href in rendered output means Quarto (or the shard
+                # merge) failed to rewrite it: the reader gets served source.
+                if path.endswith(".qmd"):
+                    findings.append(Finding("unrewritten-qmd", value, rel_page))
+                    continue
+
+                target = resolve(root, dirpath, path)
+                if target is None:
+                    findings.append(Finding("missing-target", value, rel_page))
+                    continue
+
+                if check_anchors and split.fragment:
+                    fragment = unquote(split.fragment)
+                    if fragment not in anchors_of(target, anchor_cache):
+                        findings.append(Finding("missing-anchor", value, rel_page))
+
+    return findings, pages
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", default="_build", help="rendered site (default: _build)")
+    parser.add_argument("--allow", help="allowlist file of known-broken entries")
+    parser.add_argument(
+        "--anchors",
+        action="store_true",
+        help=(
+            "also check #fragments. Off by default: quartodoc does not emit "
+            "id attributes for the objects its own interlinks target, so this "
+            "currently reports ~1500 findings from generated api/** pages."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    root = os.path.normpath(args.dir)
+    if not os.path.isdir(root):
+        print(f"error: no such render directory: {root}", file=sys.stderr)
+        print("Build the site first (e.g. `make site-parallel`).", file=sys.stderr)
+        return 2
+
+    findings, pages = check(root, check_anchors=args.anchors)
+
+    allowed = load_allowlist(args.allow)
+    kept = [f for f in findings if f"{f.kind}\t{f.target}" not in allowed]
+    suppressed = len(findings) - len(kept)
+
+    by_kind: dict[str, list[Finding]] = defaultdict(list)
+    for finding in kept:
+        by_kind[finding.kind].append(finding)
+
+    print(f"Scanned {pages} pages in {root}/")
+    if suppressed:
+        print(f"Suppressed {suppressed} allowlisted finding(s) from {args.allow}")
+
+    if not kept:
+        print("No broken internal links found.")
+        return 0
+
+    for kind in sorted(by_kind):
+        group = by_kind[kind]
+        print(f"\n{kind} ({len(group)}):")
+        for finding in sorted(group, key=lambda f: (f.target, f.source)):
+            print(f"  {finding.target}\n      in {finding.source}")
+
+    print(f"\n{len(kept)} broken internal link(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/page-links-allow.txt
+++ b/scripts/page-links-allow.txt
@@ -1,0 +1,16 @@
+# Known-broken internal links, suppressed so `make check-page-links` can gate
+# on regressions. Format: <kind><TAB><target>, one per line; a leading '#' is a
+# comment (a mid-line '#' is a URL fragment, not a comment).
+#
+# Kinds emitted by scripts/check-page-links.py:
+#   missing-target    the link resolves to no file or directory index
+#   missing-anchor    the page exists but has no element with that id/name
+#   unrewritten-qmd   a .qmd href survived rendering (reader gets served source)
+#
+# Every entry should reference the issue tracking its fix. Prefer fixing the
+# link over adding a line here.
+
+# #447 -- py-shiny's shiny/otel/__init__.py docstring links to
+# `../../examples/open-telemetry/`, a path relative to the py-shiny repo layout,
+# not the site. Must be fixed upstream; drop this entry after a submodule bump.
+missing-target	../../examples/open-telemetry/

--- a/scripts/test_check_page_links.py
+++ b/scripts/test_check_page_links.py
@@ -1,0 +1,170 @@
+"""Unit tests for scripts/check-page-links.py.
+
+Not collected by `make test-apps` (pytest.ini scopes testpaths to components/).
+Run explicitly:
+
+    uv run pytest scripts/test_check_page_links.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_page_links", Path(__file__).with_name("check-page-links.py")
+)
+assert _SPEC and _SPEC.loader
+check_page_links = importlib.util.module_from_spec(_SPEC)
+sys.modules["check_page_links"] = check_page_links
+_SPEC.loader.exec_module(check_page_links)
+
+
+@pytest.fixture
+def site(tmp_path: Path) -> Path:
+    """A minimal rendered site: sub/page.html linking at real/index.html."""
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "real").mkdir()
+    (tmp_path / "real" / "index.html").write_text('<h2 id="known">k</h2>')
+    return tmp_path
+
+
+def findings(root: Path, *, anchors: bool = True) -> set[tuple[str, str]]:
+    found, _pages = check_page_links.check(str(root), check_anchors=anchors)
+    return {(f.kind, f.target) for f in found}
+
+
+def write_page(site: Path, body: str) -> None:
+    (site / "sub" / "page.html").write_text(body)
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "../real/",  # directory with an index.html
+        "../real/index.html",  # direct file
+        "/real/",  # root-absolute, resolved against the render dir
+        "../real/index.html#known",  # anchor that exists
+    ],
+)
+def test_resolvable_links_are_not_reported(site: Path, href: str) -> None:
+    write_page(site, f'<a href="{href}">x</a>')
+    assert findings(site) == set()
+
+
+@pytest.mark.parametrize(
+    "href",
+    [
+        "https://example.com/x",  # external
+        "//cdn.example.com/x.js",  # protocol-relative
+        "mailto:a@b.c",
+        "#local",  # same-page fragment
+        "${href}",  # JS template literal
+        "<%= app.shinylive %>",  # EJS placeholder
+        "../site_libs/bootstrap/x.min.css",  # merge-owned hashed asset
+        "",
+    ],
+)
+def test_non_site_links_are_skipped(site: Path, href: str) -> None:
+    write_page(site, f'<a href="{href}">x</a>')
+    assert findings(site) == set()
+
+
+@pytest.mark.parametrize(
+    "wrapper",
+    ["<pre>{}</pre>", "<code>{}</code>", "<script>{}</script>"],
+)
+def test_code_and_script_regions_are_ignored(site: Path, wrapper: str) -> None:
+    """Samples name files like `my-styles.css` that are not meant to resolve."""
+    write_page(site, wrapper.format('<a href="my-styles.css">x</a>'))
+    assert findings(site) == set()
+
+
+def test_missing_target_is_reported(site: Path) -> None:
+    write_page(site, '<a href="../gone.html">x</a>')
+    assert findings(site) == {("missing-target", "../gone.html")}
+
+
+def test_relative_link_missing_leading_slash_is_reported(site: Path) -> None:
+    """The py-shiny-site #59 follow-up bug: `templates/x/` instead of `/templates/x/`."""
+    write_page(site, '<a href="real/">x</a>')
+    assert findings(site) == {("missing-target", "real/")}
+
+
+def test_directory_without_index_is_reported(site: Path) -> None:
+    (site / "empty").mkdir()
+    write_page(site, '<a href="../empty/">x</a>')
+    assert findings(site) == {("missing-target", "../empty/")}
+
+
+def test_unrewritten_qmd_is_reported_even_when_the_file_exists(site: Path) -> None:
+    """Quarto copies some unresolved .qmd files through; the link is still wrong."""
+    (site / "real" / "index.qmd").write_text("source")
+    write_page(site, '<a href="../real/index.qmd">x</a>')
+    assert findings(site) == {("unrewritten-qmd", "../real/index.qmd")}
+
+
+def test_missing_anchor_is_reported(site: Path) -> None:
+    write_page(site, '<a href="../real/index.html#nope">x</a>')
+    assert findings(site) == {("missing-anchor", "../real/index.html#nope")}
+
+
+def test_anchor_checking_is_off_by_default_in_main(site: Path) -> None:
+    """quartodoc omits the ids its own interlinks target; gating on anchors
+    would report ~1500 findings from generated api/** pages."""
+    write_page(site, '<a href="../real/index.html#nope">x</a>')
+    assert check_page_links.main(["--dir", str(site)]) == 0
+    assert check_page_links.main(["--dir", str(site), "--anchors"]) == 1
+
+
+def test_name_attribute_counts_as_an_anchor(site: Path) -> None:
+    (site / "real" / "index.html").write_text('<a name="legacy"></a>')
+    write_page(site, '<a href="../real/index.html#legacy">x</a>')
+    assert findings(site) == set()
+
+
+def test_percent_encoded_paths_resolve(site: Path) -> None:
+    (site / "real" / "a b.html").write_text("x")
+    write_page(site, '<a href="../real/a%20b.html">x</a>')
+    assert findings(site) == set()
+
+
+def test_query_string_is_stripped_before_resolving(site: Path) -> None:
+    write_page(site, '<a href="../real/index.html?v=1">x</a>')
+    assert findings(site) == set()
+
+
+def test_src_attributes_are_checked(site: Path) -> None:
+    write_page(site, '<img src="../missing.png">')
+    assert findings(site) == {("missing-target", "../missing.png")}
+
+
+def test_allowlist_suppresses_by_kind_and_target(tmp_path: Path) -> None:
+    allow = tmp_path / "allow.txt"
+    allow.write_text(
+        "# a leading-hash comment\nmissing-target\t../gone.html\n\n"
+        # A mid-line '#' is a URL fragment, not a comment.
+        "missing-anchor\t../real/index.html#nope\n"
+    )
+    entries = check_page_links.load_allowlist(str(allow))
+    assert entries == {
+        "missing-target\t../gone.html",
+        "missing-anchor\t../real/index.html#nope",
+    }
+
+
+def test_main_exits_2_when_the_render_dir_is_absent(tmp_path: Path) -> None:
+    assert check_page_links.main(["--dir", str(tmp_path / "nope")]) == 2
+
+
+def test_main_exits_0_on_a_clean_site(site: Path) -> None:
+    write_page(site, '<a href="../real/">x</a>')
+    assert check_page_links.main(["--dir", str(site)]) == 0
+
+
+def test_main_exits_1_when_findings_remain(site: Path) -> None:
+    write_page(site, '<a href="../gone.html">x</a>')
+    assert check_page_links.main(["--dir", str(site)]) == 1


### PR DESCRIPTION
Adds `scripts/check-page-links.py` and fixes the broken links it turned up. This is the "check first" step; the CI wiring (`test-docs/page-links`) lands with the workflow regroup in #445.

## Why Quarto doesn't already catch this

Quarto validates `.qmd` links and nothing else. A link with no extension is passed through verbatim, so `templates/dashboard/` (missing its leading slash) rendered as `href="templates/dashboard/"` and silently 404'd, while the correct sibling in the same sentence became `href="../templates/database-explorer/"`. That's the #59 follow-up bug from #442.

## What it reports

| kind | meaning |
| --- | --- |
| `missing-target` | resolves to no file or directory index |
| `unrewritten-qmd` | a `.qmd` href survived rendering — the reader is served source |
| `missing-anchor` | page exists, no element with that `id`/`name` (**opt-in**, `--anchors`) |

Known-broken links go in `scripts/page-links-allow.txt` as `<kind><TAB><target>`.

## Baseline: clean

Measured on a full `make site-parallel` build (6 shards + merge, 616 pages):

```
$ make check-page-links
Scanned 616 pages in _build/
Suppressed 1 allowlisted finding(s) from scripts/page-links-allow.txt
No broken internal links found.
```

5 broken targets found, 4 fixed here, 1 allowlisted (#447 — a py-shiny docstring links to `../../examples/open-telemetry/`, relative to the *repo* layout, so it must be fixed upstream). `unrewritten-qmd` is zero: `ci-merge.py` resolved 4,851 `.qmd` hrefs in that run.

## Links fixed

- **`docs/opentelemetry/_resources.qmd`** — three dead links in one bullet list: `/api/` has no landing page (only `/api/core/` and `/api/express/` exist), and `docs/testing/` and `docs/performance/` do not exist at all. Repointed to `/api/core/`, `/docs/end-to-end-testing.qmd`, `/docs/nonblocking.qmd`.
- **`components/outputs/plot-seaborn/index.qmd`** — `plot-matplotlib.html#plots-as-inputs`; the target is a directory, so `../plot-matplotlib/index.qmd`. Same bug as the image page.
- **`docs/express-in-depth.qmd`** (×3), **`docs/nonblocking.qmd`** — `../api/Session.html` predates the `api/core/` split; the nonblocking one was also missing its `../`.
- **`docs/jupyter-widgets.qmd`** (×2) — `../api/render.ui.html` likewise.
- **`components/outputs/image/index.qmd`** — a literal `href="TODO ADD LINK"`, plus the `plot-matplotlib.html` link.
- **`docs/genai-chatbots.qmd`** — `[Bootstrap icons]((https://…))`; the doubled paren made the URL part of the link text.

## Anchor checking is opt-in, deliberately

I had planned to gate on anchors. The data says no: `--anchors` reports 1,490 findings, **1,461 of them from generated `api/**`**. quartodoc emits interlinks like `../../api/core/App.html#shiny.App` but writes no matching `id` — verified that `_build/api/core/App.html` has only `#parameters`, `#methods`, `#examples`, `#attributes` plus Quarto chrome. Every API object interlink is a dead fragment. That needs an upstream fix, so gating on it today would be unactionable noise.

The 29 findings outside `api/**` are mostly real, and 18 are one cluster: links to `layouts/panels-cards/#content-divided-by-cards` where the rendered id is `#listing-variation-content-divided-by-cards` (the variations listing prefixes its ids). Diagnosed and tracked in #448.

## Tests

`scripts/test_check_page_links.py` — 29 tests, run via `make test-check-page-links`. Not picked up by `make test-apps` (pytest.ini scopes `testpaths` to `components/`).

```
$ make test-check-page-links
29 passed in 0.13s
```

They cover each finding kind, each skip rule (external, protocol-relative, `mailto:`, bare fragment, JS/EJS template placeholders, `site_libs/`, `<pre>`/`<code>`/`<script>` regions), percent-encoded paths, query strings, `name=` anchors, and the three exit codes. One of them was written because the first draft had a real bug: stripping `#` comments from the allowlist also ate URL fragments, so anchor entries could never be suppressed.

## Note on measurement

An earlier count of these findings was taken against a stale `make serve` build and was wrong in both directions — it flagged 2,000+ phantom `site_libs/` misses and an `api/core/index.html` `.qmd` leak that the shard merge actually resolves, while missing pages that hadn't been rendered locally at all. Everything above is from a fresh full parallel build; `make check-page-links` should only be trusted after `make site-parallel`, which is now documented in CLAUDE.md.