### PR TITLE
docs: drop stale claims that Shiny Express lacks modules

### DIFF
--- a/docs/express-or-core.qmd
+++ b/docs/express-or-core.qmd
@@ -59,7 +59,7 @@ Given its longer history, Shiny Core is naturally more mature than Shiny Express
 We've carefully designed the Shiny Express syntax, and hope not to have to make breaking changes to it.
 However, we don't know what we don't know, and it's possible that user feedback or our own testing will someday require us to make significant changes.
 
-Similarly, we are constantly testing Shiny Express, but as of this writing, it has not has as much real-world use as Shiny Core.
+Similarly, we are constantly testing Shiny Express, but as of this writing, it has not had as much real-world use as Shiny Core.
 Therefore, with Shiny Core, you are less likely to encounter bugs.
 
 ## Familiarity to R users

--- a/docs/express-or-core.qmd
+++ b/docs/express-or-core.qmd
@@ -40,15 +40,15 @@ Compare their respective source code, and consider:
 
 ## Feature set
 
-**Consider using Shiny Core if you need to use Shiny Modules or dynamic UI.**
+**Consider using Shiny Core if you need the options that live on the `ui.output_*()` functions.**
 
 At this time, Shiny Core's functionality is a superset of Express, meaning that anything you can do in Express, you can also do in Core.
-However, the reverse is not true.
+However, the reverse is not quite true.
 
-Most importantly, [Shiny Modules](modules.qmd) are supported in Shiny Core but not (yet) in Shiny Express. Shiny Modules are extremely useful for organizing large apps into smaller, more manageable pieces, and are also a mechanism for reusing Shiny application logic.
-
-Shiny Core also has `ui.insert_ui()` and `ui.remove_ui()` functions, which is a way to imperatively add or remove UI elements from the app at any time.
-Despite being available in `shiny.express.ui`, these functions do not currently work well with Shiny Express. The same goes for `ui.modal_show()`.
+The remaining gap is a narrow one, and it's about outputs.
+In Core, you place each output yourself with a call like `ui.output_plot("plot1")`, and that call is also where some output options live, such as `ui.output_plot("plot1", brush=True)` to enable plot brushing.
+Express creates the output for you, at the spot where you define the render function, so there is no such call to pass those options to.
+Workarounds do exist---see [Express in depth](express-in-depth.qmd).
 
 ## Maturity
 

--- a/docs/modules.qmd
+++ b/docs/modules.qmd
@@ -17,11 +17,6 @@ Note that while Shiny modules are analogous to [Python modules](https://docs.pyt
 Python modules are a generic way to organize objects in a namespace, while Shiny modules are used to encapsulate reactive components in a namespace.
 :::
 
-::: callout-note
-Modules are supported in [Shiny Express](express-vs-core.qmd) apps as of version 0.10.0.
-:::
-
-
 ## Functions in Shiny
 
 One of the most important things you can do to improve your code quality is to extract a piece of logic into a function.
@@ -205,16 +200,17 @@ For example, consider this function which returns two UI elements:
 ### Express
 
 ```{.python}
-from shiny.express import expressify, input, render, module, ui
+from shiny.express import expressify, input, render, ui
 
 @expressify
 def io_row():
     with ui.layout_columns():
-        ui.input_text("text_input", "Enter text")
-
-        @render.text
-        def text_output():
-            return f'You entered "{input.text_input()}"'
+        with ui.card():
+            ui.input_text("text_input", "Enter text")
+        with ui.card():
+            @render.text
+            def text_output():
+                return f'You entered "{input.text_input()}"'
 
 io_row()
 ```
@@ -247,7 +243,8 @@ The `io_row()` function works fine in this case, but if you try to use it more t
 The reason is that Shiny requires all IDs in the UI to be unique, and if we call this function more than once, there will be several elements with the `text_input` id and several elements with the `text_output` id.
 When that happens, Shiny doesn't know how to connect particular inputs to particular outputs.
 
-One possible way to address this is to add a `prefix` argument to our function and append that to the ids of all the returned elements. (Note that this can be done with Shiny Core applications, but is difficult to do with Shiny Express.)
+One possible way to address this is to add a `prefix` argument to our function and append that to the ids of all the elements it creates.
+That works, but it's tedious and error-prone: every id in the function has to remember the prefix, and any code that reads those inputs or writes those outputs has to build the same prefixed id.
 
 Modules solve these problems by encapsulating both the UI and server logic in their own namespace.
 A module namespace can be thought of as a container for a module's code, and helps to keep the module's variables, functions, and classes separate from those in other modules.
@@ -280,7 +277,7 @@ from shiny.express import module, render, ui
 def io_row(input, output, session):
     with ui.layout_columns():
         with ui.card():
-            ui.input_text(f"text_input", "Enter text")
+            ui.input_text("text_input", "Enter text")
         with ui.card():
             @render.text
             def text_out():
@@ -321,7 +318,7 @@ from shiny.express import module, render, ui
 def io_row(input, output, session, placeholder=""):
     with ui.layout_columns():
         with ui.card():
-            ui.input_text(f"text_input", "Enter text", placeholder=placeholder)
+            ui.input_text("text_input", "Enter text", placeholder=placeholder)
         with ui.card():
             @render.text
             def text_out():


### PR DESCRIPTION
Closes #171.

### The stale content

`docs/modules.qmd` had already been flipped to a positive "supported as of version 0.10.0" callout, and the page the issue's link points at (`docs/express-vs-core.qmd`) never claimed modules were Core-only. The actual offender was **`docs/express-or-core.qmd`** ("Choosing a syntax"), whose *Feature set* section still said modules were supported "in Shiny Core but not (yet) in Shiny Express."

That same section also claimed `ui.insert_ui()`, `ui.remove_ui()`, and `ui.modal_show()` "do not currently work well with Shiny Express." I checked: an Express app calling all three from `@reactive.effect`s works (shiny 1.7.1.dev6 — the note was inserted at its selector and the modal showed, driven with Playwright). So that claim is gone too, and the section now describes only the gap I could still confirm: Express creates outputs implicitly, so there is no `ui.output_*()` call to pass output options like `brush=True` to.

### Changes

`docs/express-or-core.qmd`

- *Feature set* rewritten around the one real remaining difference. Modules and `insert_ui`/`remove_ui`/`modal_show` aren't differences, so they're no longer mentioned here at all — `modules.qmd` covers modules with Express/Core tabs throughout.

`docs/modules.qmd`

- Removed the version callout about Express support.
- Rewrote the aside that said adding a `prefix` argument "can be done with Shiny Core applications, but is difficult to do with Shiny Express" — it's equally tedious in either syntax, which is the actual point that motivates modules.
- Example fixes: dropped an unused `module` import from the `@expressify` `io_row()` example and gave it the same cards as its Core counterpart; removed two spurious `f"text_input"` f-string prefixes.

### Verification

- Both pages render clean with the pinned Quarto 1.9.36.
- The edited `@expressify` example runs as a real app.
- No component pages touched, so no shinylive-link regeneration needed.

### Left alone, deliberately

The *Maturity* section of `express-or-core.qmd` still says Express "has not had as much real-world use as Shiny Core" and that Core makes you "less likely to encounter bugs." Written in 2024 and plausibly stale now, but unlike the module claims it isn't checkable from the code — it's an editorial call about how we position Express, so it's filed separately as #451 rather than decided here.
