### PR TITLE
docs: fix stale heading anchors reported by site_links.py --anchors

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Internal-link checker
         run: make test-site-links-checker
 
+      - name: Generated-api anchor fixup
+        run: make test-api-anchors
+
   done-test-docs:
     if: always()
     needs: [relevant-functions, shinylive-links, unit]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,18 +338,22 @@ The custom renderer automatically extracts examples from `py-shiny/shiny/example
 **`make test-site-links`** — scans the rendered site in `_build/` for broken internal links (`scripts/test_site_links.py`). Requires a current full build; run `make site-parallel` first. Reports three kinds:
 
 - `missing-target` — the link resolves to no file or directory index
-- `missing-anchor` — the page exists but has no element with that `id`/`name` (**opt-in**, `--anchors`)
+- `missing-anchor` — the page exists but has no element with that `id`/`name` (`--anchors`, which `make test-site-links` passes)
 - `unrewritten-qmd` — a `.qmd` href survived rendering, so the reader is served source
 
 This exists because Quarto only validates `.qmd` links. A link with no extension (e.g. `templates/dashboard/` instead of `/templates/dashboard/`) is passed through verbatim and silently 404s — see #59's follow-up. Known-broken links are suppressed via `scripts/site-links-allow.txt` (`<kind><TAB><target>`); prefer fixing the link over adding an entry.
 
 In CI this is `site.yml`'s `page-links` job, running against the `site-merged` artifact that `combine` produced — not a `test-docs` job, since nothing there has a rendered site. See "Other CI checks".
 
-**Anchor checking is off by default and not gateable yet.** quartodoc emits interlinks like `api/core/App.html#shiny.App` but never writes a matching `id` attribute on the target page, so `--anchors` reports ~1,500 findings, ~1,460 of them from generated `api/**` output. The ~33 findings originating outside `api/**` are mostly real stale heading anchors — tracked in #448.
+**Anchor checking is gated, and stays that way only because of `scripts/api_anchors.py`.** quartodoc puts an explicit anchor on every documented object's heading and records the URL in `objects.json`, but Quarto promotes a generated page's first heading into the title block and drops its attributes — so `api/core/App.html` had `#shiny.App.run` and no `#shiny.App`. That, plus re-export aliases whose inventory path (`shiny.Session.close`) differs from the heading quartodoc generated (`shiny.session.Session.close`), left 1,463 dead fragments across 293 distinct targets.
+
+`api_anchors.py` runs from the **post-render hook** and injects an empty `<span>` carrying each promised-but-missing id: the page's own object goes on the title block (that heading *is* the title block), an alias goes on the heading documenting the same object, so both land where the reader expects. It adds nothing that the page's qmd or the inventory did not already promise — an undocumented object that something links to stays broken on purpose, because that is a real docs bug and the checker should keep reporting it. Idempotent, and it runs on partial renders too so `make serve` previews what CI gates.
+
+Consequence for anything touching generated api output: **`make test-site-links` now fails on a dead `#shiny.*` fragment.** If a submodule bump breaks it, run `python3 scripts/api_anchors.py --dir _build` — it prints how many promised anchors it could not place, and `plan_anchors` is where the three rules live. Unit tests: `make test-api-anchors`.
 
 **Run it after `make site-parallel`, not `make serve`.** A partial or seeded `_build/` produces large numbers of false positives: `site_libs/` asset hashes drift (excluded for this reason), and unmerged shard output leaves `.qmd` hrefs that `scripts/ci-merge.py` would have rewritten (it resolved 4,851 of them in one measured run).
 
-Unit tests for the checker live in `scripts/test_site_links.py` and are **not** collected by the `test-components-*` targets (pytest.ini scopes `testpaths` to `components/`). Run them with `make test-site-links-checker`; `test-docs`' `unit` job runs the same target in CI.
+Unit tests for the checker live in `scripts/test_site_links.py`, and for the anchor fixup in `scripts/test_api_anchors.py`. Neither is collected by the `test-components-*` targets (pytest.ini scopes `testpaths` to `components/`). Run them with `make test-site-links-checker` and `make test-api-anchors`; `test-docs`' `unit` job runs both targets in CI.
 
 **`make compare-versions`** — viewport comparison between production and a local build using Playwright + Claude vision via AWS Bedrock. Run it before merging any change that could affect rendered output site-wide: Quarto version upgrades, Shinylive version upgrades, `_quarto.yml` structural changes, `_renderer.py` changes, or other dependency upgrades. Writes a timestamped markdown report to `tests/`; start with the executive summary.
 

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,17 @@ site-parallel: $(PYBIN) install-quarto
 # a uv install to run a stdlib script -- or, worse, invite CI to invoke the script
 # directly and duplicate these flags. Keep it dependency-free so there is exactly
 # one definition of how the check is run. (Verified on Python 3.9.)
-## Check the rendered site in _build for broken internal links (run `make site-parallel` first)
+#
+# --anchors is on: scripts/api_anchors.py (via the post-render hook) restores the
+# object anchors Quarto drops from the generated api/** pages, so fragments are
+# now checkable site-wide rather than reporting ~1,460 dead api interlinks. If
+# this starts failing on api/** after a submodule bump, suspect a promised anchor
+# with no heading to attach to -- `python3 scripts/api_anchors.py --dir _build`
+# reports how many it could not place.
+## Check the rendered site in _build for broken internal links and anchors (run `make site-parallel` first)
 .PHONY: test-site-links
 test-site-links:
-	python3 scripts/site_links.py --dir _build --allow scripts/site-links-allow.txt
+	python3 scripts/site_links.py --dir _build --anchors --allow scripts/site-links-allow.txt
 
 # Tests scripts/site_links.py itself. pytest.ini scopes testpaths to components/,
 # so this file is never collected by the test-components-* targets.
@@ -94,6 +101,12 @@ test-site-links:
 .PHONY: test-site-links-checker
 test-site-links-checker: $(PYBIN)
 	$(UVRUN) pytest scripts/test_site_links.py -n0
+
+# Same deal for the anchor fixup that makes --anchors gateable.
+## Unit-test the generated-api anchor fixup
+.PHONY: test-api-anchors
+test-api-anchors: $(PYBIN)
+	$(UVRUN) pytest scripts/test_api_anchors.py -n0
 
 ## Serve existing _build without full re-render (fast preview; run `make site` or `make site-parallel` first)
 .PHONY: serve-fast

--- a/docs/express-in-depth.qmd
+++ b/docs/express-in-depth.qmd
@@ -237,7 +237,7 @@ In this case, it's just a single card, but there's no limit to how much or how l
 In Shiny Core, UI objects are just normal objects, so you can assign them to variables no differently than you would an integer or a list.
 :::
 
-### Problem: Reactively rendering UI
+### Problem: Reactively rendering UI {#problem-reactively-rendering-ui}
 
 So far, all of the UI we've generated has been "static"---it's generated once, when the page loads, and never changes.
 It's pretty common in Shiny to want to generate UI in response to user input or server events.

--- a/docs/express-vs-core.qmd
+++ b/docs/express-vs-core.qmd
@@ -164,7 +164,7 @@ Broadly speaking, there are two kinds of UI components in Shiny: _container comp
 Here are some examples of container components:
 
 - [`ui.sidebar()`](../layouts/sidebars/index.qmd)
-- [`ui.card()`](../layouts/panels-cards/index.qmd#content-divided-by-cards)
+- [`ui.card()`](../layouts/panels-cards/index.qmd#multiple-cards)
 - [`ui.layout_columns()`](../layouts/arrange/index.qmd#grid-layouts)
 - `ui.div()`
 

--- a/docs/genai-chatbots.qmd
+++ b/docs/genai-chatbots.qmd
@@ -394,7 +394,7 @@ app = App(app_ui, server)
 Another useful UI pattern is to embed the chat component inside a `ui.card()`.
 If nothing else, this will help visually separate the chat from the rest of the app.
 It also provides a natural place to provide a header (with perhaps a [tooltip](../components/display-messages/tooltips/index.qmd) with more info about your chatbot).
-[Cards](../layouts/panels-cards/index.qmd#content-divided-by-cards) also come with other handy features like `full_screen=True` to make the chat full-screen when embedded inside a larger app.
+[Cards](../layouts/panels-cards/index.qmd#multiple-cards) also come with other handy features like `full_screen=True` to make the chat full-screen when embedded inside a larger app.
 
 ::: {.panel-tabset .panel-pills}
 
@@ -635,7 +635,7 @@ async def _(user_input: str):
 :::
 
 
-Suggestions are a great way to help guide users throughout a multi-turn conversation (for real examples, see [here](genai-inspiration.qmd#guided-exploration-🧭)).
+Suggestions are a great way to help guide users throughout a multi-turn conversation (for real examples, see [here](genai-inspiration.qmd#guided-exploration)).
 To accomplish this, you'll need to instruct the AI how to generate suggestions itself.
 We've found that adding a section like the one below to your [`system_prompt`](#models-prompts) to be effective for this:
 
@@ -1122,7 +1122,7 @@ When deploying AI chatbots to production, [OpenTelemetry tracing](opentelemetry.
 - Understand user interaction patterns
 - Debug issues without accessing production logs
 
-Many observability platforms like [Logfire](opentelemetry.qmd#quick-setup-with-logfire) can automatically instrument AI libraries (OpenAI, Anthropic, etc.) to show API calls nested within your Shiny traces.
+Many observability platforms like [Logfire](opentelemetry.qmd#logfire) can automatically instrument AI libraries (OpenAI, Anthropic, etc.) to show API calls nested within your Shiny traces.
 
 ## Next steps
 

--- a/docs/genai-inspiration.qmd
+++ b/docs/genai-inspiration.qmd
@@ -92,7 +92,7 @@ Specifically, by clicking on the ✨ icon, the user is provided with a natural l
 ![Screenshot of the "sidebot" app with a tooltip describing the visualization.](/images/genai-sidebot-tooltip.png){class="rounded shadow lightbox mt-3"}
 
 
-### Guided exploration 🧭
+### Guided exploration 🧭 {#guided-exploration}
 
 Chatbots are also a great way to guide users through an experience, such as a story, game, or learning activity.
 The `Chat()` component's [input suggestion](genai-chatbots.qmd#suggest-input) feature provides a particularly useful interface for this, as it makes it very easy for users to 'choose their own adventure' with little to no typing.

--- a/docs/genai-tools.qmd
+++ b/docs/genai-tools.qmd
@@ -285,12 +285,12 @@ async def update_dashboard(
 ::: callout-note
 ### Reactive locking
 
-Since this tool runs within a [non-blocking message stream](genai-tools.qmd#non-blocking-streams) (i.e., `.append_message_stream()`), in order to prevent race conditions, it must lock the reactivity graph when updating reactive value(s).
+Since this tool runs within a [non-blocking message stream](genai-chatbots.qmd#non-blocking-streams) (i.e., `.append_message_stream()`), in order to prevent race conditions, it must lock the reactivity graph when updating reactive value(s).
 If the tool were, instead, running in a [blocking stream](genai-chatbots.qmd#message-stream-context), the `reactive.lock()` and `reactive.flush()` wouldn't be necessary.
 :::
 
 The final crucial piece is that, in order for the LLM to generate accurate SQL, it needs to know the schema of the dataset.
-This is done by passing the table schema to the LLM's [system prompt](genai-chatbots.qmd#models--prompts).
+This is done by passing the table schema to the LLM's [system prompt](genai-chatbots.qmd#models-prompts).
 
 Since the general pattern of having a tool to update a reactive data frame via SQL is so useful, the [querychat](../templates/querychat/index.qmd) package generalizes this pattern to make it more accessible and easier to use.
 

--- a/docs/opentelemetry/_quick-start.qmd
+++ b/docs/opentelemetry/_quick-start.qmd
@@ -48,7 +48,7 @@ Everything is configurable through standard [OpenTelemetry environment variables
 - Auto-instrumentation also instruments other libraries your app uses (HTTP clients, databases, etc.), so their spans appear alongside Shiny's.
 - `shiny run --reload` works; the reloaded process inherits the instrumentation.
 
-### Logfire (Observability Backend Service)
+### Logfire (Observability Backend Service) {#logfire}
 
 [Pydantic Logfire](https://logfire.pydantic.dev/) provides zero-configuration OpenTelemetry setup with a managed observability platform. You will need to set up a Logfire account and project.
 

--- a/docs/persistent-storage.qmd
+++ b/docs/persistent-storage.qmd
@@ -157,7 +157,7 @@ data = reactive.value(load_data())
 
 from the `app.py` file to the `setup.py` file -- this changes `data` from being a user-scoped reactive value to a globally-scoped reactive value (i.e. [shared among all users](express-in-depth.qmd#shared-objects)).
 
-Sharing data in this way works fine when only users can change the data, but it wouldn't work in a scenario where data can be changed outside of the app (e.g., another app or a database admin). In this case, we would need to periodically check for updates using something like [reactive polling](reading-data.qmd#reactive-reading).
+Sharing data in this way works fine when only users can change the data, but it wouldn't work in a scenario where data can be changed outside of the app (e.g., another app or a database admin). In this case, we would need to periodically check for updates using something like [reactive polling](reading-data.qmd#reactive).
 
 ### SQL injection
 

--- a/docs/ui-dynamic.qmd
+++ b/docs/ui-dynamic.qmd
@@ -93,7 +93,7 @@ def result():
 ::: callout-warning
 ## Render UI vs display
 
-Shiny Express code that works via side-effects needs to be used with `@render.express`, not `@render.ui`. See [this section](express-in-depth.qmd#reactive-displays) to learn more.
+Shiny Express code that works via side-effects needs to be used with `@render.express`, not `@render.ui`. See [this section](express-in-depth.qmd#problem-reactively-rendering-ui) to learn more.
 :::
 
 ::: callout-tip

--- a/get-started/debug.qmd
+++ b/get-started/debug.qmd
@@ -48,7 +48,7 @@ def slider_val():
 
 ```
 
-This happens because, if a non-existent input is read, a [`SilentException`](/api/express/req.html#shiny) is raised.
+This happens because, if a non-existent input is read, a [`SilentException`](/api/core/ExceptionTypes.html#shiny.types.SilentException) is raised.
 That behavior is useful for events and [dynamic ui](/docs/ui-dynamic.qmd), but it can be confusing when you mistype an input id.
 
 ::: {.callout-tip}

--- a/layouts/index.qmd
+++ b/layouts/index.qmd
@@ -369,7 +369,7 @@ Use cards and panels to define areas of related content.
 
 
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
-<a class="component-list-header-text" href="panels-cards/#content-divided-by-cards">
+<a class="component-list-header-text" href="panels-cards/#multiple-cards">
 <div class="component-list-header">
 <div class="h5">Content in cards</div>
 <div class="component-list-icon">
@@ -379,7 +379,7 @@ Use cards and panels to define areas of related content.
 </div>
 </div>
 <div class="component-list-card layout-list-card">
-<p class="layout-list-image my-0"><a class="component-list-header-text" href="panels-cards/#content-divided-by-cards">
+<p class="layout-list-image my-0"><a class="component-list-header-text" href="panels-cards/#multiple-cards">
   <img alt="" src="/images/two-cards.png" class="h-100 w-100">
 </p>
 </div>
@@ -388,7 +388,7 @@ Use cards and panels to define areas of related content.
 
 
 <div class="g-col-md-4 g-col-sm-6 g-col-12 component-list-column">
-<a class="component-list-header-text" href="panels-cards/#main-image-with-panel-floating-above">
+<a class="component-list-header-text" href="panels-cards/#floating-panel">
 <div class="component-list-header">
 <div class="h5">Floating panel</div>
 <div class="component-list-icon">

--- a/layouts/panels-cards/index.qmd
+++ b/layouts/panels-cards/index.qmd
@@ -213,7 +213,7 @@ Use `ui.layout_sidebar()` inside a card to create a card with a sidebar layout. 
 :::{#variation-card-sidebar}
 :::
 
-## Floating panel
+## Floating panel {#floating-panel}
 
 :::{.column-screen-inset-right style="max-width:800px;"}
 ```{python}

--- a/scripts/api_anchors.py
+++ b/scripts/api_anchors.py
@@ -1,0 +1,254 @@
+"""Restore the object anchors that Quarto drops from generated ``api/**`` pages.
+
+quartodoc writes an explicit anchor onto every documented object's heading
+(``# App { #shiny.App }``) and records the resulting URL in ``objects.json``,
+the interlink inventory that every ``:func:``/``:class:`` reference in a
+docstring resolves through. Two things then break that contract:
+
+1. **The page's own object loses its id.** Its heading is the first ``#`` in the
+   file, so Quarto promotes it into the title block -- and drops the attributes,
+   including the id. ``api/core/App.html`` ends up with ``#shiny.App.run`` and
+   friends but no ``#shiny.App``. This is the bulk of it: 290 of the 293 dead
+   fragments on the site.
+
+2. **Re-export aliases don't match.** The inventory advertises the public path
+   (``shiny.Session.close``) while the page is generated from the canonical one
+   (``shiny.session.Session.close``), so the heading id and the link disagree.
+
+Both leave the reader at the top of the page instead of at the definition, and
+neither is visible to Quarto's own link checking, which only validates ``.qmd``
+links. This module closes the gap by post-processing the rendered HTML: where a
+promised fragment is missing, it injects an empty ``<span>`` carrying that id at
+the right place.
+
+Three rules decide what to add, in order of how directly the evidence ties an
+anchor to a location:
+
+``own-heading``
+    The sibling ``.qmd``'s first heading carries ``{ #path }`` but the HTML has
+    no such id -- exactly the id Quarto swallowed. Goes on the title block,
+    which is what that heading became.
+``primary-object``
+    The inventory promises ``<page>#shiny.<page stem>``. Covers pages whose qmd
+    has no id to read because the object is spread over the page rather than
+    titling it (``api/core/Session.qmd`` starts with a bare ``# Session``).
+``alias``
+    The inventory promises a path whose final two segments uniquely match an id
+    already on the page -- a re-export of the same object. Goes on that element,
+    so the link still lands on the definition rather than the page top.
+
+It deliberately adds nothing that neither the page nor the inventory already
+promised. An undocumented object that something links to stays broken, because
+that is a real documentation bug and ``scripts/site_links.py --anchors`` should
+keep reporting it.
+
+Run as part of ``scripts/post-render.py``, or standalone against a built site:
+
+    python3 scripts/api_anchors.py --dir _build [--source .] [--inventory objects.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+
+# Generated Quarto output quotes attributes consistently, so regexes are enough
+# here and keep this dependency-free -- the same tradeoff scripts/site_links.py
+# makes.
+ID_RE = re.compile(r'\bid="([^"]+)"')
+TITLE_BLOCK_RE = re.compile(r'<header\s+id="title-block-header"[^>]*>')
+# quartodoc's heading anchor, e.g. `# App { #shiny.App }`.
+QMD_HEADING_ID_RE = re.compile(r"^#\s+\S.*?\{\s*#(\S+?)\s*\}\s*$")
+
+# Object paths, as opposed to Quarto's own chrome ids ("quarto-content",
+# "parameters", ...). Every anchor quartodoc emits is a dotted Python path.
+OBJECT_ID_PREFIX = "shiny."
+
+
+def existing_ids(html: str) -> set[str]:
+    return set(ID_RE.findall(html))
+
+
+def qmd_heading_id(qmd_path: str) -> str | None:
+    """The explicit anchor on a generated page's first heading, if it has one."""
+    try:
+        with open(qmd_path, encoding="utf-8") as f:
+            first_line = f.readline()
+    except OSError:
+        return None
+    m = QMD_HEADING_ID_RE.match(first_line.strip())
+    return m.group(1) if m else None
+
+
+def inventory_fragments(inventory_path: str) -> dict[str, set[str]]:
+    """Map each page's site-relative path to the fragments the inventory promises."""
+    with open(inventory_path, encoding="utf-8") as f:
+        items = json.load(f)["items"]
+
+    pages: dict[str, set[str]] = {}
+    for item in items:
+        page, _, fragment = item["uri"].partition("#")
+        if fragment:
+            pages.setdefault(page, set()).add(fragment)
+    return pages
+
+
+def _element_start(html: str, anchor_id: str) -> int | None:
+    """Offset of the opening tag of the element carrying ``anchor_id``."""
+    m = re.search(r"<[a-zA-Z][^>]*\bid=\"" + re.escape(anchor_id) + r'"', html)
+    return None if m is None else m.start()
+
+
+def _alias_target(html: str, ids: set[str], fragment: str) -> int | None:
+    """Offset of the heading documenting the same object under another path.
+
+    Requires a unique match on the final two path segments, so this never
+    guesses; an ambiguous tail is left for the link checker to report.
+    """
+    tail = ".".join(fragment.split(".")[-2:])
+    candidates = [
+        i
+        for i in ids
+        if i.startswith(OBJECT_ID_PREFIX) and ".".join(i.split(".")[-2:]) == tail
+    ]
+    if len(candidates) != 1:
+        return None
+    return _element_start(html, candidates[0])
+
+
+def plan_anchors(
+    page: str,
+    html: str,
+    own_heading_id: str | None,
+    promised: set[str],
+) -> tuple[list[tuple[str, int, str]], list[str]]:
+    """Decide where each missing anchor goes.
+
+    Returns ``(insertions, unresolved)``, where an insertion is
+    ``(fragment, offset, rule)``.
+    """
+    ids = existing_ids(html)
+    stem = os.path.basename(page).removesuffix(".html")
+    title_block = TITLE_BLOCK_RE.search(html)
+
+    # The page's own object, by either route. Both land on the title block, so
+    # order only decides which rule gets the credit in the report.
+    wanted: list[tuple[str, str]] = []
+    if own_heading_id is not None:
+        wanted.append((own_heading_id, "own-heading"))
+    if (primary := OBJECT_ID_PREFIX + stem) != own_heading_id:
+        if primary in promised:
+            wanted.append((primary, "primary-object"))
+    wanted += [(f, "alias") for f in sorted(promised) if f not in dict(wanted)]
+
+    insertions: list[tuple[str, int, str]] = []
+    unresolved: list[str] = []
+    for fragment, rule in wanted:
+        if fragment in ids:
+            continue
+        if rule == "alias":
+            offset = _alias_target(html, ids, fragment)
+        else:
+            offset = None if title_block is None else title_block.end()
+        if offset is None:
+            unresolved.append(fragment)
+        else:
+            insertions.append((fragment, offset, rule))
+
+    return insertions, unresolved
+
+
+def apply_anchors(html: str, insertions: list[tuple[str, int, str]]) -> str:
+    """Inject the planned anchors. Applied back-to-front so offsets stay valid."""
+    for fragment, offset, _rule in sorted(insertions, key=lambda p: p[1], reverse=True):
+        html = f'{html[:offset]}<span id="{fragment}"></span>{html[offset:]}'
+    return html
+
+
+@dataclass
+class Report:
+    pages_changed: int = 0
+    by_rule: dict[str, int] = field(default_factory=dict)
+    unresolved: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def anchors_added(self) -> int:
+        return sum(self.by_rule.values())
+
+
+def ensure_api_anchors(
+    build_dir: str,
+    source_dir: str = ".",
+    inventory_path: str | None = "objects.json",
+    prefix: str = "api",
+) -> Report:
+    """Add every promised anchor missing from the built ``api/**`` pages."""
+    report = Report()
+    promised_by_page: dict[str, set[str]] = {}
+    if inventory_path and os.path.exists(inventory_path):
+        promised_by_page = inventory_fragments(inventory_path)
+
+    pattern = os.path.join(build_dir, prefix, "**", "*.html")
+    for path in sorted(glob.glob(pattern, recursive=True)):
+        page = os.path.relpath(path, build_dir).replace(os.sep, "/")
+
+        with open(path, encoding="utf-8") as f:
+            html = f.read()
+
+        insertions, unresolved = plan_anchors(
+            page,
+            html,
+            qmd_heading_id(os.path.join(source_dir, page[: -len(".html")] + ".qmd")),
+            promised_by_page.get(page, set()),
+        )
+        report.unresolved.extend((page, f) for f in unresolved)
+        if not insertions:
+            continue
+
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(apply_anchors(html, insertions))
+        report.pages_changed += 1
+        for _fragment, _offset, rule in insertions:
+            report.by_rule[rule] = report.by_rule.get(rule, 0) + 1
+
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir", default="_build", help="rendered site (default: _build)"
+    )
+    parser.add_argument(
+        "--source",
+        default=".",
+        help="tree holding the generated api/**/*.qmd (default: .)",
+    )
+    parser.add_argument(
+        "--inventory",
+        default="objects.json",
+        help="quartodoc interlink inventory (default: objects.json)",
+    )
+    args = parser.parse_args()
+
+    report = ensure_api_anchors(args.dir, args.source, args.inventory)
+    rules = ", ".join(f"{n} {rule}" for rule, n in sorted(report.by_rule.items()))
+    print(
+        f"api-anchors: added {report.anchors_added} anchor(s) across "
+        f"{report.pages_changed} page(s) in {args.dir}" + (f" ({rules})" if rules else "")
+    )
+    # Not an error: these are inventory entries with no heading to attach to
+    # (attributes rendered into a table, undocumented members). They only matter
+    # if something links to them, and then site_links.py --anchors reports it.
+    if report.unresolved:
+        print(f"api-anchors: {len(report.unresolved)} promised anchor(s) had no target")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/post-render.py
+++ b/scripts/post-render.py
@@ -1,9 +1,23 @@
 import shutil
 import os
+import sys
 
 from pathlib import Path
 
 build_dir = Path(os.getenv("QUARTO_PROJECT_OUTPUT_DIR", "_build"))
+
+# Put back the object anchors Quarto drops from the generated api/** pages. This
+# runs before the render-all check on purpose: it is idempotent and costs well
+# under a second, and doing it on partial renders too means `make serve` previews
+# the same anchors CI gates on. See scripts/api_anchors.py.
+sys.path.insert(0, str(Path(__file__).parent))
+from api_anchors import ensure_api_anchors  # noqa: E402
+
+report = ensure_api_anchors(str(build_dir))
+print(
+    f"post-render: restored {report.anchors_added} api anchor(s) "
+    f"across {report.pages_changed} page(s)"
+)
 
 # Continue past this part only if building entire site.
 if not os.getenv("QUARTO_PROJECT_RENDER_ALL"):

--- a/scripts/test_api_anchors.py
+++ b/scripts/test_api_anchors.py
@@ -1,0 +1,238 @@
+"""Unit tests for scripts/api_anchors.py, the generated-api anchor fixup.
+
+Not collected by the test-components-* targets (pytest.ini scopes testpaths to
+components/). Run explicitly:
+
+    make test-api-anchors
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# pytest's default "prepend" import mode puts scripts/ on sys.path (no
+# __init__.py here), so the module imports as a plain module.
+import api_anchors
+
+TITLE_BLOCK = '<header id="title-block-header" class="quarto-title-block default">'
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A source tree and a build dir sharing the api/core/ layout."""
+    (tmp_path / "api" / "core").mkdir(parents=True)
+    (tmp_path / "_build" / "api" / "core").mkdir(parents=True)
+    return tmp_path
+
+
+def write_page(tree: Path, stem: str, *, qmd: str, html: str) -> Path:
+    (tree / "api" / "core" / f"{stem}.qmd").write_text(qmd)
+    path = tree / "_build" / "api" / "core" / f"{stem}.html"
+    path.write_text(html)
+    return path
+
+
+def write_inventory(tree: Path, uris: list[str]) -> Path:
+    path = tree / "objects.json"
+    path.write_text(json.dumps({"items": [{"name": u, "uri": u} for u in uris]}))
+    return path
+
+
+def run(tree: Path, inventory: Path | None = None) -> api_anchors.Report:
+    return api_anchors.ensure_api_anchors(
+        str(tree / "_build"),
+        source_dir=str(tree),
+        inventory_path=str(inventory) if inventory else None,
+    )
+
+
+def test_own_heading_anchor_goes_on_the_title_block(tree: Path) -> None:
+    """The id Quarto swallowed off the first heading is restored."""
+    page = write_page(
+        tree,
+        "App",
+        qmd="# App { #shiny.App }\n\nbody\n",
+        html=f"<html>{TITLE_BLOCK}<h1>App</h1></header></html>",
+    )
+
+    report = run(tree)
+
+    assert '<span id="shiny.App"></span>' in page.read_text()
+    assert page.read_text().index('id="shiny.App"') > page.read_text().index(
+        'id="title-block-header"'
+    )
+    assert report.by_rule == {"own-heading": 1}
+
+
+def test_existing_anchor_is_left_alone(tree: Path) -> None:
+    """A page whose object id survived rendering is not touched."""
+    page = write_page(
+        tree,
+        "App",
+        qmd="# App { #shiny.App }\n",
+        html=f'<html>{TITLE_BLOCK}</header><section id="shiny.App">x</section></html>',
+    )
+    before = page.read_text()
+
+    report = run(tree)
+
+    assert page.read_text() == before
+    assert report.anchors_added == 0
+
+
+def test_rerunning_adds_nothing(tree: Path) -> None:
+    """Idempotent: post-render may run over an already-processed build."""
+    page = write_page(
+        tree,
+        "App",
+        qmd="# App { #shiny.App }\n",
+        html=f"<html>{TITLE_BLOCK}</header></html>",
+    )
+
+    run(tree)
+    once = page.read_text()
+    second = run(tree)
+
+    assert page.read_text() == once
+    assert second.anchors_added == 0
+
+
+def test_heading_without_an_explicit_id_is_not_invented(tree: Path) -> None:
+    """A bare `# Exception types` page gets no made-up `shiny.ExceptionTypes`."""
+    page = write_page(
+        tree,
+        "ExceptionTypes",
+        qmd="# Exception types\n\nbody\n",
+        html=f"<html>{TITLE_BLOCK}</header></html>",
+    )
+
+    report = run(tree)
+
+    assert "shiny.ExceptionTypes" not in page.read_text()
+    assert report.anchors_added == 0
+
+
+def test_primary_object_comes_from_the_inventory(tree: Path) -> None:
+    """api/core/Session.qmd has no heading id, so the inventory supplies it."""
+    page = write_page(
+        tree,
+        "Session",
+        qmd="# Session\n\nTools for managing user sessions.\n",
+        html=f"<html>{TITLE_BLOCK}</header></html>",
+    )
+    inventory = write_inventory(tree, ["api/core/Session.html#shiny.Session"])
+
+    report = run(tree, inventory)
+
+    assert '<span id="shiny.Session"></span>' in page.read_text()
+    assert report.by_rule == {"primary-object": 1}
+
+
+def test_alias_attaches_to_the_canonical_heading(tree: Path) -> None:
+    """`shiny.Session.close` lands on the `shiny.session.Session.close` heading."""
+    page = write_page(
+        tree,
+        "Session",
+        qmd="# Session\n",
+        html=(
+            f"<html>{TITLE_BLOCK}</header>"
+            '<section id="shiny.session.Session.close">close</section></html>'
+        ),
+    )
+    inventory = write_inventory(tree, ["api/core/Session.html#shiny.Session.close"])
+
+    report = run(tree, inventory)
+
+    html = page.read_text()
+    assert '<span id="shiny.Session.close"></span><section' in html
+    assert report.by_rule == {"alias": 1}
+
+
+def test_ambiguous_alias_is_left_unresolved(tree: Path) -> None:
+    """Two candidates sharing a tail means no anchor rather than a guess."""
+    page = write_page(
+        tree,
+        "Session",
+        qmd="# Session\n",
+        html=(
+            f"<html>{TITLE_BLOCK}</header>"
+            '<section id="shiny.a.Session.close">a</section>'
+            '<section id="shiny.b.Session.close">b</section></html>'
+        ),
+    )
+    inventory = write_inventory(tree, ["api/core/Session.html#shiny.Session.close"])
+
+    report = run(tree, inventory)
+
+    assert 'id="shiny.Session.close"' not in page.read_text()
+    assert report.unresolved == [("api/core/Session.html", "shiny.Session.close")]
+
+
+def test_promised_anchor_with_no_target_is_reported_not_faked(tree: Path) -> None:
+    """An undocumented member stays broken so the link checker still flags it."""
+    page = write_page(
+        tree,
+        "App",
+        qmd="# App { #shiny.App }\n",
+        html=f"<html>{TITLE_BLOCK}</header></html>",
+    )
+    inventory = write_inventory(tree, ["api/core/App.html#shiny.App.lib_prefix"])
+
+    report = run(tree, inventory)
+
+    assert "lib_prefix" not in page.read_text()
+    assert report.unresolved == [("api/core/App.html", "shiny.App.lib_prefix")]
+
+
+def test_multiple_anchors_on_one_page_all_land(tree: Path) -> None:
+    """Back-to-front insertion keeps offsets valid across several edits."""
+    page = write_page(
+        tree,
+        "Session",
+        qmd="# Session\n",
+        html=(
+            f"<html>{TITLE_BLOCK}</header>"
+            '<section id="shiny.session.Session.close">close</section>'
+            '<section id="shiny.session.Session.on_flush">flush</section></html>'
+        ),
+    )
+    inventory = write_inventory(
+        tree,
+        [
+            "api/core/Session.html#shiny.Session",
+            "api/core/Session.html#shiny.Session.close",
+            "api/core/Session.html#shiny.Session.on_flush",
+        ],
+    )
+
+    run(tree, inventory)
+
+    html = page.read_text()
+    assert '<span id="shiny.Session.close"></span><section id="shiny.session.Session.close"' in html
+    assert (
+        '<span id="shiny.Session.on_flush"></span><section id="shiny.session.Session.on_flush"'
+        in html
+    )
+    assert f'{TITLE_BLOCK}<span id="shiny.Session"></span>' in html
+
+
+def test_pages_absent_from_a_shard_are_skipped(tree: Path) -> None:
+    """Each shard renders a slice; the inventory covers the whole site."""
+    inventory = write_inventory(tree, ["api/core/Missing.html#shiny.Missing"])
+
+    report = run(tree, inventory)
+
+    assert report.anchors_added == 0
+    assert report.unresolved == []
+
+
+def test_page_without_a_title_block_is_reported(tree: Path) -> None:
+    """No title block means nowhere safe to put the page's own anchor."""
+    write_page(tree, "App", qmd="# App { #shiny.App }\n", html="<html><h1>App</h1></html>")
+
+    report = run(tree)
+
+    assert report.unresolved == [("api/core/App.html", "shiny.App")]

--- a/templates/basic-chatbot/index.qmd
+++ b/templates/basic-chatbot/index.qmd
@@ -42,7 +42,7 @@ Just change `ChatAnthropic()` with another provider (e.g., [`ChatOpenAI()`](http
 ::: {.g-col-6 .g-col-sm-4}
 **Layouts:**
 
-* [Cards](/layouts/panels-cards/#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/dashboard-tips/index.qmd
+++ b/templates/dashboard-tips/index.qmd
@@ -46,7 +46,7 @@ Another notable difference is the use of `plotly` for interactive plots.
 
 * [Sidebar](/layouts/sidebars)
 * [Grid layout](/layouts/arrange)
-* [Cards](/layouts/panels-cards/#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/dashboard/index.qmd
+++ b/templates/dashboard/index.qmd
@@ -41,7 +41,7 @@ In addition to demonstrating the basics visual components of a dashboard, it als
 
 * [Sidebar](../../layouts/sidebars/index.qmd)
 * [Grid layout](../../layouts/arrange/index.qmd)
-* [Cards](../../layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](../../layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/dinner-recipe/index.qmd
+++ b/templates/dinner-recipe/index.qmd
@@ -37,7 +37,7 @@ By wrapping the chat in a `card()` component, the card footer offers a natural p
 ::: {.g-col-6 .g-col-sm-4}
 **Layouts:**
 
-* [Cards](/layouts/panels-cards/#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/map-distance/index.qmd
+++ b/templates/map-distance/index.qmd
@@ -42,7 +42,7 @@ Note also the use of Shiny [modules](/docs/modules.qmd) to encapsulate and reuse
 
 * [Sidebar](/layouts/sidebars/index.qmd)
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/model-scoring/index.qmd
+++ b/templates/model-scoring/index.qmd
@@ -39,7 +39,7 @@ Shiny's reactive programming model makes it easy and performant to update those 
 * [Sidebar](/layouts/sidebars/index.qmd)
 * [Tabs](/layouts/tabs/index.qmd)
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/monitor-database/index.qmd
+++ b/templates/monitor-database/index.qmd
@@ -43,7 +43,7 @@ Note also that this template has:
 
 * [Sidebar](/layouts/sidebars/index.qmd)
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/monitor-file/index.qmd
+++ b/templates/monitor-file/index.qmd
@@ -41,7 +41,7 @@ Note also that this app shows the entire log in a data grid, and the most recent
 **Layouts:**
 
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/monitor-folder/index.qmd
+++ b/templates/monitor-folder/index.qmd
@@ -44,7 +44,7 @@ Additionally, when a file is selected in this table, the contents are displayed 
 **Layouts:**
 
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/nba-dashboard/index.qmd
+++ b/templates/nba-dashboard/index.qmd
@@ -42,7 +42,7 @@ This provides a useful way to query player(s) based on a specific statistic, the
 
 * [Sidebar](/layouts/sidebars/index.qmd)
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/querychat/index.qmd
+++ b/templates/querychat/index.qmd
@@ -31,7 +31,7 @@ To learn more, visit [querychat's website](https://github.com/posit-dev/querycha
 ::: {.g-col-6 .g-col-sm-4}
 **Layouts:**
 
-* [Cards](/layouts/panels-cards/#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/sidebot/index.qmd
+++ b/templates/sidebot/index.qmd
@@ -35,7 +35,7 @@ See [Joe Cheng's `posit::conf(2024)` presentation](https://www.youtube.com/watch
 ::: {.g-col-6 .g-col-sm-4}
 **Layouts:**
 
-* [Cards](/layouts/panels-cards/#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/#multiple-cards)
 * [Grid layout](/layouts/arrange/index.qmd#grid-layouts)
 
 :::

--- a/templates/stock-app/index.qmd
+++ b/templates/stock-app/index.qmd
@@ -44,7 +44,7 @@ Note that the icon for the stock price change is a green arrow pointing up if th
 
 * [Sidebar](/layouts/sidebars/index.qmd)
 * [Grid layout](/layouts/arrange/index.qmd)
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}

--- a/templates/survey-wizard/index.qmd
+++ b/templates/survey-wizard/index.qmd
@@ -37,7 +37,7 @@ We also make clever use of [`navset_hidden()`](/api/core/ui.navset_hidden.qmd) t
 
 **Layouts:**
 
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 * [Tabs](/layouts/tabs/index.qmd)
 
 :::

--- a/templates/survey/index.qmd
+++ b/templates/survey/index.qmd
@@ -41,7 +41,7 @@ In this example, we use the [shiny_validate] package for input validation, provi
 
 **Layouts:**
 
-* [Cards](/layouts/panels-cards/index.qmd#content-divided-by-cards)
+* [Cards](/layouts/panels-cards/index.qmd#multiple-cards)
 
 :::
 ::: {.g-col-6 .g-col-sm-4}


### PR DESCRIPTION
Closes #448.

`scripts/site_links.py --anchors` reported 1,490 findings. This PR takes it to **0** and turns the anchor check on in CI, so dead fragments can't come back silently.

## 1. The 29 authored-page findings

| Fix | Count |
| --- | --- |
| `layouts/panels-cards/#content-divided-by-cards` → `#multiple-cards` | 18 |
| `panels-cards/#main-image-with-panel-floating-above` → `#floating-panel` | 1 |
| `genai-tools.qmd#non-blocking-streams` → `genai-chatbots.qmd#non-blocking-streams` | 1 |
| `#models--prompts` → `#models-prompts` | 1 |
| `#guided-exploration-🧭` → `#guided-exploration` | 1 |
| `#quick-setup-with-logfire` → `#logfire` | 1 |
| `#reactive-displays` → `#problem-reactively-rendering-ui` | 1 |
| `#reactive-reading` → `#reactive` | 1 |
| `/api/express/req.html#shiny` → `/api/core/ExceptionTypes.html#shiny.types.SilentException` | 1 |

The card cluster targets the authored `{#multiple-cards}` heading rather than the listing's `listing-variation-…` id, which is an implementation detail of the listing partial. Every one of the 9 targets now has an **explicit** `{#id}`, four of them pinned here, so a future heading rename can't rot these links again.

`/api/express/req.html#shiny` was listed in the issue as "Group 1 in disguise," but `#shiny` is a typo that could never resolve; it now points at the page that documents `SilentException`.

## 2. The 1,461 `api/**` findings — not a quartodoc bug

The issue attributes these to quartodoc never writing object anchors. That turns out to be wrong. quartodoc emits `# App { #shiny.App }` and records the URL in `objects.json`. The id vanishes because **Quarto promotes a page's first heading into the title block and drops its attributes** — `api/core/App.html` kept `#shiny.App.run` (an H3) and lost only `#shiny.App`. `api/core/ExceptionTypes.qmd` proves the mechanism: it opens with a bare `# Exception types`, so its objects aren't first and their ids survive.

Of 293 distinct dead fragments: 290 were that, and 3 were re-export aliases where the inventory advertises `shiny.Session.close` while the generated heading is `shiny.session.Session.close`.

`scripts/api_anchors.py` runs from the post-render hook and injects an empty `<span>` carrying each promised-but-missing id — the page's own object onto the title block (that heading *is* the title block), an alias onto the heading documenting the same object, so both land where the reader expects. Three rules, ordered by how directly the evidence ties an anchor to a place:

- `own-heading` — the sibling qmd's first-heading id (286)
- `primary-object` — the inventory promises `#shiny.<page stem>`, for pages like `Session.qmd` whose qmd has no id to read (4)
- `alias` — a unique final-two-segment match, so it never guesses (7)

It adds nothing the qmd or the inventory didn't already promise. The ~375 inventory entries for attributes rendered into tables get no anchor, and an undocumented object that something links to stays broken on purpose — that's a real docs bug and the checker should keep reporting it.

## Gating

`make test-site-links` now passes `--anchors`, so `site.yml`'s `page-links` job checks fragments site-wide. This means **step 3 of the issue is done too** — no `api/**` exclusion was needed, so #448 closes in full.

## Verification

- Full `make site-parallel`: `--anchors` went **1,463 → 0**; re-running the fixup adds 0 anchors (idempotent)
- `make test-api-anchors` — 11 cases, wired into `test-docs`' `unit` job
- `make test-site-links-checker` — 29 cases, still green

Not run: `make compare-versions` (needs Bedrock creds unavailable here). The change only inserts empty `<span>` elements into generated api pages, so no visual diff is expected, but that isn't proven by a vision comparison.

Rebased onto #449 and #453, both of which merged mid-review; #453 renamed the checker to `scripts/site_links.py` / `make test-site-links` and this PR follows the new names.