### PR TITLE
fix: drop the /py prefix from the modal redirect source

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -38,7 +38,7 @@
 /components/outputs/verbatim-text.html          /py/components/outputs/verbatim-text/index.html
 
 /py/components/outputs/datatable/* /py/components/outputs/data-table/:splat
-/py/components/display-messages/modal/* /py/components/layout/modal/:splat
+/components/display-messages/modal/* /py/components/layout/modal/:splat
 
 /layouts/arrange.html      /py/layouts/arrange/index.html
 /layouts/navbars.html      /py/layouts/navbars/index.html


### PR DESCRIPTION
Follow-up to #455.

## Summary

The splat redirect added in #455 for the old modal directory URL was written with a `/py/` prefix on the source, copying the neighbouring `datatable` rule. That form does not work: Netlify prepends the site's `/py` base path to `_redirects` sources, so `/py/components/display-messages/modal/*` only matches `/py/py/components/display-messages/modal/*`. This drops the prefix so the rule matches the URL readers actually have.

The pre-existing `/py/components/outputs/datatable/*` rule has the same defect and is left alone here, since fixing it is unrelated to the modal move — worth a separate pass over the file.

## Verification

Measured against production, which still has the pre-#455 rules:

```
/py/components/display-messages/modal.html      301  (source in file: /components/...)   works
/py/components/outputs/datatable/               404  (source in file: /py/components/...) dead
/py/py/components/outputs/datatable/            301                                       confirms the prefix is prepended
```

After deploy, `https://shiny.posit.co/py/components/display-messages/modal/` should 301 to `/py/components/layout/modal/`.