### PR TITLE
fix: hide the stray copy button on shinylive app previews

### DIFF
--- a/components/_partials/components.css
+++ b/components/_partials/components.css
@@ -92,6 +92,15 @@ main a.nav-link:hover {
   height: 200px;
 }
 
+/* Quarto attaches a copy button to every `pre.sourceCode`, including the
+   shinylive source block that shinylive's JS then replaces in place with the
+   running app. The button survives that swap and floats over the top right of
+   the preview, where it would copy nothing useful — the source is already
+   offered (with its own copy button) in the code tabs below. */
+.app-preview .code-copy-button {
+  display: none;
+}
+
 /* Improve spacing for app previews */
 .app-preview {
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary

Live shinylive previews on the component and layout detail pages show a clipboard button floating over their top-right corner. It isn't shinylive's — it's Quarto's, orphaned by shinylive's DOM swap.

The shinylive Lua filter leaves the app source as an ordinary Pandoc code block (`pre.sourceCode.shinylive-python`) and hands the app JSON to the client. Quarto's `htmlFormatPostprocessor` then wraps *every* `pre.sourceCode` in a `div.code-copy-outer-scaffold` and appends a `button.code-copy-button` as a **sibling** — unconditionally, with no per-block opt-out. Shinylive's JS replaces the `div.sourceCode` in place with the running app, so the button survives and ends up absolutely positioned over the app. `code-copy: true` in `_quarto.yml` makes it always visible rather than hover-only.

The fix hides copy buttons inside `.app-preview`, which is precisely the set of live shinylive previews — emitted by `components/_partials/shiny-example-panel.ejs` and `docs/helpers.py:shinylive_app_preview`, and used nowhere else in the site. Both sections load `components/_partials/components.css`, which already carries a sibling workaround for the same swap (`.shinylive-python code { visibility: hidden }`); the button was the piece that got missed.

CSS rather than JS on purpose: the button's fate must not depend on whether our script runs before or after shinylive's async swap.

Scope note: shinylive embeds outside `.app-preview` (editor+viewer blocks in `docs/`, API reference examples) still carry the same orphaned button. Left alone here to keep the change narrow.

## Verification

Rendered both affected page shapes with the pinned Quarto 1.9.36 and checked computed styles in a browser against the local build:

- `components/layout/accordion/` — 3 preview buttons `display: none`, 6 code-tab buttons untouched.
- `layouts/arrange/` — 9 preview buttons hidden, 0 still showing, 18 code-tab buttons untouched.

To see it by hand: `make serve`, open `/components/layout/accordion/`, and confirm no clipboard icon over the preview at the top of the page while the Express/Core tabs below keep theirs.