### PR TITLE
docs: clarify the Agent Skills install precondition

### DIFF
--- a/get-started/agent-skills.qmd
+++ b/get-started/agent-skills.qmd
@@ -19,8 +19,16 @@ Because the skill ships with the package, it always matches the version of `shin
 
 ## Install the skill into your project
 
-Once `shiny` is a dependency of your project, use [`library-skills`](https://library-skills.io) to make the bundled skill available to your agent.
-Run these commands from your own project directory (where `shiny` is installed) — `library-skills` finds the skill in your installed `shiny` package, so this is not tied to the py-shiny source repository.
+The skill ships inside the package, so installing `shiny` installs it too — you only need to point your agent at it.
+Use [`library-skills`](https://library-skills.io) to do that.
+
+::: {.callout-important}
+## Run these commands from your own project directory
+
+`library-skills` reads the dependencies of whatever project you run it in, then installs the skills bundled with the packages that project has installed.
+So run it from the project where `shiny` is installed.
+Running it in an empty directory, or in a clone of the py-shiny source repository, will install nothing.
+:::
 
 ::: {.panel-tabset .panel-pills}
 
@@ -49,7 +57,9 @@ uvx library-skills --copy
 :::
 
 By default, `library-skills` symlinks the packaged skill into your project rather than copying it.
-This means the skill stays in sync automatically when you upgrade `shiny` — there is no separate step to re-install it after an upgrade.
+This means the skill keeps tracking your installed version of `shiny` as you upgrade — there is no separate step to re-install it afterwards.
+
+Because `library-skills` works from your project's dependencies rather than from any one package, the same command also installs the skills bundled with your other dependencies, if they ship any.
 
 ::: {.callout-tip}
 See `uvx library-skills --help` for the full list of options.


### PR DESCRIPTION
Companion to posit-dev/py-shiny#2447, which makes the same clarification in the README and the `shiny skills` CLI help.

## Problem

`library-skills` reads the dependencies of whatever project you run it in, and installs the skills bundled with the packages that project has installed. If you run `uvx library-skills --claude` in an empty directory — or in a clone of the py-shiny source repo — it finds nothing and installs nothing, with no explanation of why.

The page did say this, but as a clause in the middle of a paragraph directly above the code blocks. Anyone skimming to the command misses it.

## What changed

- Promoted the precondition to a `.callout-important`, and spelled out the failure mode (running it in the wrong directory installs nothing) rather than only the happy path.
- Added a line noting that the same command installs the skills of your *other* dependencies too — that's what `library-skills` actually does, and it explains why the command doesn't name `shiny`.
- Minor rewording of the symlink paragraph to match the py-shiny README.

Prose only. No commands changed.